### PR TITLE
Add interactive four-chamber PV-loop visualiser (LV · RV · LA · RA)

### DIFF
--- a/pv-loop-visualizer/README.md
+++ b/pv-loop-visualizer/README.md
@@ -1,0 +1,143 @@
+# PV-Loop Explorer
+
+An interactive, four-chamber **pressure–volume (PV) loop** visualiser for the
+left ventricle (LV), right ventricle (RV), left atrium (LA) and right atrium (RA).
+It runs a real-time, closed-loop cardiovascular simulation in the browser and lets
+you reshape the loops by dragging physiological parameters or loading clinical
+scenarios.
+
+The heart model is grounded in the **BioGears®** physiology engine: the ventricular
+activation waveform and default chamber elastances are taken directly from
+`projects/biogears/libBiogears/src/engine/Systems/Cardiovascular.cpp`
+(`CalculateHeartElastance`) and `BioGearsConfiguration.cpp`.
+
+> ⚠️ Educational tool — not for clinical use.
+
+---
+
+## Quick start
+
+No build step and no dependencies. Either:
+
+- **Open directly:** double-click `index.html` (it loads as plain `file://`), or
+- **Serve locally** (recommended):
+
+```bash
+cd pv-loop-visualizer
+python3 -m http.server 8080
+# then browse to http://localhost:8080
+```
+
+## What you can do
+
+- **Watch live loops trace** for any combination of the four chambers. Toggle
+  `LV · RV · LA · RA` with the chips above the plot. With only the atria selected
+  the axes auto-zoom so you can see the low-pressure atrial loops in detail.
+- **Drag parameters** — heart rate, blood volume (preload), per-chamber
+  contractility (Ees) and diastolic stiffness, systemic/pulmonary resistance,
+  arterial/pulmonary compliance, and stenosis/regurgitation for all four valves.
+  Every change reshapes the loops in real time. Sliders that differ from the
+  current scenario are highlighted.
+- **Load clinical scenarios** from the *Scenario* menu (see below).
+- **Read the reference relations** — the dashed **ESPVR** (contractility) and
+  **EDPVR** (compliance) curves are drawn for each visible chamber.
+- **Compare with normal** — tick *Compare with Normal* to overlay the healthy
+  resting loops as a dashed ghost.
+- **Cross-check the physiology** via the scrolling **Wiggers waveforms**
+  (LV / aortic / LA pressures and LV volume), the **cardiac schematic** (live
+  chamber filling, valve open/closed state and flow), and the **hemodynamics**
+  panel (EDV, ESV, SV, EF, pressures, MAP, CO, PA pressures).
+- **Transport controls:** *Pause* (or press `Space`), *Stabilize* (fast-forward to
+  steady state), *Reset* (return to the scenario defaults).
+
+## Scenarios
+
+| Scenario | What it demonstrates |
+|---|---|
+| Normal | Healthy resting adult (~120/8 mmHg, EF ~60%, CO ~5 L/min) |
+| Exercise | High sympathetic drive — fast, vigorous, vasodilated, high CO |
+| Systolic HF (HFrEF) | Dilated weak LV, low EF, rightward-shifted loop, congestion |
+| Diastolic HF (HFpEF) | Stiff LV, preserved EF, high filling pressures |
+| Hypertension | High afterload and stiff arteries; tall, narrow loop |
+| Hemorrhage / Hypovolemia | Reduced preload; small, leftward-shifted loops |
+| Aortic Stenosis | Large LV–aortic systolic gradient, tall square LV loop |
+| Aortic Regurgitation | Wide pulse pressure, dilated LV, loss of isovolumic relaxation |
+| Mitral Regurgitation | Giant LA v-wave, volume-overloaded LV, no true isovolumic phase |
+| Mitral Stenosis | Impeded LV filling, high LA pressure, small underfilled LV |
+| Pulmonary Hypertension | High PVR loads the RV; the RV loop enlarges markedly |
+
+## The model
+
+A lumped, closed-loop circulation links eight compartments:
+
+```
+LV ─(aortic)→ systemic arteries ─(SVR)→ systemic veins ─→ RA ─(tricuspid)→
+RV ─(pulmonic)→ pulmonary arteries ─(PVR)→ pulmonary veins ─→ LA ─(mitral)→ LV
+```
+
+- **Chambers (LV, RV, LA, RA)** develop pressure through a time-varying elastance
+  that blends an active end-systolic relation with a passive (exponential)
+  end-diastolic relation, following Burkhoff/Smith minimal-model conventions:
+
+  ```
+  P(V, t) = a(t)·Ees·(V − Vd) + (1 − a(t))·P0·(exp(λ·(V − V0)) − 1)
+  ```
+
+  The **ventricular activation** `a(t)` is the normalised double-Hill waveform used
+  by BioGears (α₁ = 0.303, α₂ = 0.508, n₁ = 1.32, n₂ = 21.9). The atria use the
+  same waveform shifted earlier in the cycle to reproduce the atrial "kick".
+- **Vessels** are linear compliances; **resistances** connect compartments.
+- **Valves** are diodes: forward flow through a small resistance, near-zero
+  backflow when competent. *Stenosis* raises the forward resistance; *regurgitation*
+  opens a backflow leak.
+- Volumes are integrated with an explicit sub-stepped solver; total blood volume is
+  conserved (preload changes adjust the systemic venous reservoir).
+
+Units throughout: pressure mmHg, volume mL, time s, flow mL/s, elastance mmHg/mL,
+compliance mL/mmHg, resistance mmHg·s/mL.
+
+### Default parameters vs. BioGears
+
+| Quantity | This model | BioGears config |
+|---|---|---|
+| LV max elastance (Ees) | 2.5 mmHg/mL | `LeftHeartElastanceMaximum` 2.49 |
+| RV max elastance (Ees) | ~1.0 mmHg/mL | `RightHeartElastanceMaximum` 1.08 |
+| Ventricular activation | double-Hill | `CalculateHeartElastance` double-Hill |
+
+BioGears models the LV and RV as time-varying elastances with passive atria; this
+tool extends that with **actively contracting atria** so all four chambers produce
+true PV loops.
+
+## Files
+
+```
+pv-loop-visualizer/
+├── index.html        # layout
+├── styles.css        # dark dashboard theme
+├── js/
+│   ├── model.js      # closed-loop cardiovascular model (browser + Node)
+│   ├── presets.js    # clinical scenarios
+│   ├── plots.js      # canvas renderers (PV loops, Wiggers, schematic)
+│   ├── ui.js         # controls, presets, metrics
+│   └── app.js        # animation loop + glue
+└── tools/
+    └── tune.js       # headless Node harness for validating the model
+```
+
+## Validating the model headlessly
+
+`tools/tune.js` runs the model to steady state under Node and prints per-chamber
+EDV/ESV/SV/EF and circulatory pressures — handy for retuning parameters:
+
+```bash
+node pv-loop-visualizer/tools/tune.js all      # every preset
+node pv-loop-visualizer/tools/tune.js hfref     # one scenario
+```
+
+## References
+
+- BioGears Cardiovascular Methodology (`Cardiovascular.cpp`).
+- Stergiopulos N, et al. *Elastance of the canine left ventricle* — double-Hill
+  activation form.
+- Burkhoff D, et al. *Pressure–volume analysis of the cardiovascular system*.
+- Smith BW, et al. *Minimal haemodynamic system model* (closed-loop elastance model).

--- a/pv-loop-visualizer/index.html
+++ b/pv-loop-visualizer/index.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>BioGears PV-Loop Explorer — LV · RV · LA · RA</title>
+  <meta name="description" content="Interactive four-chamber pressure–volume loop visualiser built on a closed-loop time-varying-elastance cardiovascular model." />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="app-header">
+    <div class="brand">
+      <div class="brand-mark" aria-hidden="true">
+        <svg viewBox="0 0 32 32" width="28" height="28">
+          <path d="M16 28S4 20 4 12a6 6 0 0 1 12-2 6 6 0 0 1 12 2c0 8-12 16-12 16z" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
+          <polyline points="3,16 10,16 13,9 17,23 20,16 29,16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </div>
+      <div class="brand-text">
+        <h1>PV-Loop Explorer</h1>
+        <p>Four-chamber pressure–volume modelling · LV · RV · LA · RA</p>
+      </div>
+    </div>
+    <div class="header-controls">
+      <label class="preset-field">
+        <span>Scenario</span>
+        <select id="presetSelect" aria-label="Clinical scenario preset"></select>
+      </label>
+      <div class="transport">
+        <button id="playBtn" class="btn btn-primary" title="Play / pause (space)">Pause</button>
+        <button id="stabilizeBtn" class="btn" title="Fast-forward to a steady state">Stabilize</button>
+        <button id="resetBtn" class="btn" title="Reset to scenario defaults">Reset</button>
+      </div>
+    </div>
+  </header>
+
+  <p id="scenarioBlurb" class="scenario-blurb"></p>
+
+  <main class="layout">
+    <!-- Controls -->
+    <aside class="panel controls" id="controls">
+      <div class="panel-head">
+        <h2>Controls</h2>
+        <span class="hint">Drag to explore physiology</span>
+      </div>
+      <div id="controlGroups"></div>
+    </aside>
+
+    <!-- PV loops (hero) -->
+    <section class="panel pv-panel">
+      <div class="panel-head">
+        <h2>Pressure–Volume Loops</h2>
+        <div class="chamber-toggles" id="chamberToggles"></div>
+      </div>
+      <div class="canvas-wrap pv-wrap">
+        <canvas id="pvCanvas"></canvas>
+      </div>
+      <div class="pv-options">
+        <label class="check"><input type="checkbox" id="showRelations" checked /> ESPVR / EDPVR lines</label>
+        <label class="check"><input type="checkbox" id="autoScale" checked /> Auto-scale axes</label>
+        <label class="check"><input type="checkbox" id="showGhost" /> Compare with Normal</label>
+      </div>
+    </section>
+
+    <!-- Right column: waveforms + heart + metrics -->
+    <section class="panel wave-panel">
+      <div class="panel-head"><h2>Wiggers Waveforms</h2><span class="hint" id="waveHint"></span></div>
+      <div class="canvas-wrap wave-wrap">
+        <canvas id="waveCanvas"></canvas>
+      </div>
+    </section>
+
+    <section class="panel heart-panel">
+      <div class="panel-head"><h2>Cardiac Schematic</h2><span class="hint">Live filling &amp; valves</span></div>
+      <div class="canvas-wrap heart-wrap">
+        <canvas id="heartCanvas"></canvas>
+      </div>
+    </section>
+
+    <section class="panel metrics-panel">
+      <div class="panel-head"><h2>Hemodynamics</h2><span class="hint" id="beatHint"></span></div>
+      <div id="metrics" class="metrics"></div>
+    </section>
+  </main>
+
+  <footer class="app-footer">
+    <span>Closed-loop time-varying-elastance model · ventricular activation &amp; elastances follow the BioGears engine (<code>Cardiovascular.cpp</code>).</span>
+    <span class="disclaimer">Educational tool — not for clinical use.</span>
+  </footer>
+
+  <script src="js/model.js"></script>
+  <script src="js/presets.js"></script>
+  <script src="js/plots.js"></script>
+  <script src="js/ui.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/pv-loop-visualizer/js/app.js
+++ b/pv-loop-visualizer/js/app.js
@@ -1,0 +1,303 @@
+/*
+ * app.js — Application glue. Owns the model, runs the animation loop, records
+ * per-beat loop / waveform buffers, computes hemodynamic metrics, smooths the
+ * plot axes, and wires the UI controls to the model.
+ */
+(function (root) {
+  'use strict';
+
+  var PV = root.PVLoop;
+  var CHAMBERS = ['lv', 'rv', 'la', 'ra'];
+
+  // ---- shared sampling helpers ------------------------------------------------
+  function emptyCycle() { return { lv: [], rv: [], la: [], ra: [], saMin: Infinity, saMax: -Infinity, saSum: 0, paMin: Infinity, paMax: -Infinity, paSum: 0, n: 0 }; }
+
+  // Sample exactly one cardiac cycle (aligned to a beat boundary) without disturbing
+  // the caller's expectations — used to seed initial loops and the "Normal" ghost.
+  function sampleOneCycle(model, n) {
+    n = n || 600;
+    var startBeat = model.beat;
+    while (model.beat === startBeat) model._step();
+    var T = model.period();
+    var dtS = T / n;
+    var cyc = emptyCycle();
+    for (var i = 0; i < n; i++) {
+      model.advance(dtS);
+      for (var ci = 0; ci < CHAMBERS.length; ci++) {
+        var k = CHAMBERS[ci];
+        cyc[k].push({ v: model.V[k], p: model.P[k] });
+      }
+      accum(cyc, model);
+    }
+    return cyc;
+  }
+
+  function accum(cyc, model) {
+    var sa = model.P.sa, pa = model.P.pa;
+    if (sa < cyc.saMin) cyc.saMin = sa;
+    if (sa > cyc.saMax) cyc.saMax = sa;
+    if (pa < cyc.paMin) cyc.paMin = pa;
+    if (pa > cyc.paMax) cyc.paMax = pa;
+    cyc.saSum += sa; cyc.paSum += pa; cyc.n++;
+  }
+
+  function chamberStats(arr) {
+    var edv = -Infinity, esv = Infinity, pMax = -Infinity, pMin = Infinity, pSum = 0;
+    for (var i = 0; i < arr.length; i++) {
+      var s = arr[i];
+      if (s.v > edv) edv = s.v;
+      if (s.v < esv) esv = s.v;
+      if (s.p > pMax) pMax = s.p;
+      if (s.p < pMin) pMin = s.p;
+      pSum += s.p;
+    }
+    var sv = edv - esv;
+    return { edv: edv, esv: esv, sv: sv, ef: edv > 0 ? (sv / edv) * 100 : 0, pMax: pMax, pMin: pMin, pMean: pSum / arr.length };
+  }
+
+  function metricsFromCycle(cyc, hr) {
+    var lv = chamberStats(cyc.lv), rv = chamberStats(cyc.rv);
+    var la = chamberStats(cyc.la), ra = chamberStats(cyc.ra);
+    var map = cyc.n ? cyc.saSum / cyc.n : 0;
+    var pamean = cyc.n ? cyc.paSum / cyc.n : 0;
+    return {
+      lv: lv, rv: rv, la: la, ra: ra,
+      sys: { sbp: cyc.saMax, dbp: cyc.saMin, map: map },
+      pulm: { pas: cyc.paMax, pad: cyc.paMin, pamean: pamean },
+      co: (lv.sv * hr) / 1000, hr: hr
+    };
+  }
+
+  // ---- application state ------------------------------------------------------
+  var model = new PV.CVModel();
+  var baseline = Object.assign({}, model.params); // current preset's params
+  var visible = { lv: true, rv: true, la: false, ra: false };
+  var opts = { running: true, speed: 1, showRelations: true, autoScale: true, showGhost: false };
+
+  var rec = {
+    loop: { lv: [], rv: [], la: [], ra: [] },
+    cur: { lv: [], rv: [], la: [], ra: [] },
+    cyc: emptyCycle(),
+    wave: [],
+    span: 4.0,
+    lastBeat: 0,
+    metrics: null
+  };
+  var axis = { vMax: 200, pMax: 140 };
+  var waveScale = { p: 140, v: 160 };
+  var ghost = null;
+  var phase = 0;
+
+  // ---- DOM ----
+  var el = {
+    pv: document.getElementById('pvCanvas'),
+    wave: document.getElementById('waveCanvas'),
+    heart: document.getElementById('heartCanvas'),
+    metrics: document.getElementById('metrics'),
+    controls: document.getElementById('controlGroups'),
+    toggles: document.getElementById('chamberToggles'),
+    preset: document.getElementById('presetSelect'),
+    blurb: document.getElementById('scenarioBlurb'),
+    beatHint: document.getElementById('beatHint'),
+    waveHint: document.getElementById('waveHint'),
+    play: document.getElementById('playBtn'),
+    reset: document.getElementById('resetBtn'),
+    stabilize: document.getElementById('stabilizeBtn'),
+    showRelations: document.getElementById('showRelations'),
+    autoScale: document.getElementById('autoScale'),
+    showGhost: document.getElementById('showGhost')
+  };
+
+  var controlsApi = PV.ui.buildControls(el.controls, model.params, baseline, function (key, value) {
+    if (key === 'bloodVolume') model.setBloodVolume(value);
+    else model.params[key] = value;
+  });
+
+  PV.ui.buildChamberToggles(el.toggles, visible, function () {});
+
+  PV.ui.buildPresetSelect(el.preset, PV.presets, applyPreset);
+
+  function computeGhost() {
+    var g = new PV.CVModel();
+    g.settle(16);
+    var cyc = sampleOneCycle(g, 400);
+    ghost = { lv: cyc.lv, rv: cyc.rv, la: cyc.la, ra: cyc.ra };
+  }
+
+  function seedFromCycle() {
+    // jump to steady state and pre-fill loops + metrics so the UI is populated at t=0
+    model.settle(14);
+    var cyc = sampleOneCycle(model, 400);
+    CHAMBERS.forEach(function (k) { rec.loop[k] = cyc[k]; });
+    rec.metrics = metricsFromCycle(cyc, model.params.heartRate);
+    rec.lastBeat = model.beat;
+    rec.cur = { lv: [], rv: [], la: [], ra: [] };
+    rec.cyc = emptyCycle();
+    rec.wave = [];
+    PV.ui.renderMetrics(el.metrics, rec.metrics);
+  }
+
+  function applyPreset(name) {
+    var preset = PV.presets[name];
+    if (!preset) return;
+    var params = Object.assign(PV.defaultParams(), preset.params);
+    model.params = params;
+    model.reset();
+    baseline = Object.assign({}, params);
+    controlsApi.refresh(model.params, baseline);
+    el.blurb.textContent = preset.blurb;
+    el.preset.value = name;
+    seedFromCycle();
+  }
+
+  // ---- recording during live animation ---------------------------------------
+  function record() {
+    for (var ci = 0; ci < CHAMBERS.length; ci++) {
+      var k = CHAMBERS[ci];
+      rec.cur[k].push({ v: model.V[k], p: model.P[k] });
+    }
+    accum(rec.cyc, model);
+    rec.wave.push({ t: model.t, plv: model.P.lv, psa: model.P.sa, pla: model.P.la, vlv: model.V.lv });
+
+    if (model.beat !== rec.lastBeat) {
+      for (var i = 0; i < CHAMBERS.length; i++) {
+        var c = CHAMBERS[i];
+        if (rec.cur[c].length > 4) rec.loop[c] = rec.cur[c];
+        rec.cur[c] = [];
+      }
+      // Chamber stats come from the just-completed loops; aortic/PA stats from the
+      // per-cycle scalar accumulator (rec.cyc).
+      var completed = {
+        lv: rec.loop.lv, rv: rec.loop.rv, la: rec.loop.la, ra: rec.loop.ra,
+        saMin: rec.cyc.saMin, saMax: rec.cyc.saMax, saSum: rec.cyc.saSum,
+        paMin: rec.cyc.paMin, paMax: rec.cyc.paMax, paSum: rec.cyc.paSum, n: rec.cyc.n
+      };
+      rec.metrics = metricsFromCycle(completed, model.params.heartRate);
+      rec.cyc = emptyCycle();
+      rec.lastBeat = model.beat;
+      PV.ui.renderMetrics(el.metrics, rec.metrics);
+      if (el.beatHint) el.beatHint.textContent = 'beat ' + model.beat;
+    }
+
+    // trim waveform buffer to the visible span
+    var cutoff = model.t - rec.span;
+    while (rec.wave.length && rec.wave[0].t < cutoff) rec.wave.shift();
+  }
+
+  // ---- axis smoothing ---------------------------------------------------------
+  function updateAxes() {
+    var vTarget, pTarget;
+    if (opts.autoScale) {
+      var vm = 0, pm = 0;
+      CHAMBERS.forEach(function (k) {
+        if (!visible[k]) return;
+        var arrs = [rec.loop[k], rec.cur[k]];
+        if (opts.showGhost && ghost && ghost[k]) arrs.push(ghost[k]);
+        arrs.forEach(function (arr) {
+          for (var i = 0; i < arr.length; i++) {
+            if (arr[i].v > vm) vm = arr[i].v;
+            if (arr[i].p > pm) pm = arr[i].p;
+          }
+        });
+      });
+      vTarget = Math.max(80, Math.ceil((vm * 1.12) / 20) * 20);
+      pTarget = Math.max(30, Math.ceil((pm * 1.14) / 10) * 10);
+    } else {
+      var ventricle = visible.lv || visible.rv;
+      vTarget = ventricle ? 260 : 120;
+      pTarget = ventricle ? 220 : 45;
+    }
+    axis.vMax += (vTarget - axis.vMax) * 0.10;
+    axis.pMax += (pTarget - axis.pMax) * 0.10;
+  }
+
+  function updateWaveScale() {
+    var pm = 60, vm = 100;
+    for (var i = 0; i < rec.wave.length; i++) {
+      if (rec.wave[i].psa > pm) pm = rec.wave[i].psa;
+      if (rec.wave[i].plv > pm) pm = rec.wave[i].plv;
+      if (rec.wave[i].vlv > vm) vm = rec.wave[i].vlv;
+    }
+    var pT = Math.ceil((pm * 1.1) / 20) * 20;
+    var vT = Math.ceil((vm * 1.15) / 20) * 20;
+    waveScale.p += (pT - waveScale.p) * 0.08;
+    waveScale.v += (vT - waveScale.v) * 0.08;
+  }
+
+  // ---- main loop --------------------------------------------------------------
+  var lastTs = 0;
+  function frame(ts) {
+    var dtReal = lastTs ? (ts - lastTs) / 1000 : 0;
+    lastTs = ts;
+    phase = (phase + dtReal * 1.4) % 1;
+
+    if (opts.running) {
+      var simSeconds = Math.min(0.05, opts.speed * dtReal); // clamp jumps
+      var sampleDt = 0.004;
+      var remaining = simSeconds;
+      var guard = 0;
+      while (remaining > 1e-6 && guard < 400) {
+        var step = Math.min(sampleDt, remaining);
+        model.advance(step);
+        record();
+        remaining -= step;
+        guard++;
+      }
+    } else {
+      model._evaluate();
+    }
+
+    updateAxes();
+    updateWaveScale();
+
+    PV.plots.drawPVLoops(el.pv, {
+      model: model, axis: axis, visible: visible,
+      loop: rec.loop, cur: rec.cur,
+      head: { lv: peek(rec.cur.lv, rec.loop.lv), rv: peek(rec.cur.rv, rec.loop.rv), la: peek(rec.cur.la, rec.loop.la), ra: peek(rec.cur.ra, rec.loop.ra) },
+      showRelations: opts.showRelations,
+      ghost: opts.showGhost ? ghost : null
+    });
+    PV.plots.drawWaves(el.wave, {
+      wave: rec.wave, span: rec.span, tNow: model.t,
+      pScale: waveScale.p, vScale: waveScale.v
+    });
+    PV.plots.drawHeart(el.heart, { model: model, phase: phase });
+
+    requestAnimationFrame(frame);
+  }
+
+  function peek(cur, loop) {
+    if (cur && cur.length) return cur[cur.length - 1];
+    if (loop && loop.length) return loop[loop.length - 1];
+    return null;
+  }
+
+  // ---- control wiring ---------------------------------------------------------
+  el.play.addEventListener('click', function () {
+    opts.running = !opts.running;
+    el.play.textContent = opts.running ? 'Pause' : 'Play';
+    el.play.classList.toggle('btn-primary', opts.running);
+  });
+  el.reset.addEventListener('click', function () { applyPreset(el.preset.value); });
+  el.stabilize.addEventListener('click', function () { seedFromCycle(); });
+  el.showRelations.addEventListener('change', function () { opts.showRelations = el.showRelations.checked; });
+  el.autoScale.addEventListener('change', function () { opts.autoScale = el.autoScale.checked; });
+  el.showGhost.addEventListener('change', function () { opts.showGhost = el.showGhost.checked; });
+
+  document.addEventListener('keydown', function (e) {
+    if (e.code === 'Space' && e.target.tagName !== 'INPUT' && e.target.tagName !== 'SELECT') {
+      e.preventDefault();
+      el.play.click();
+    }
+  });
+
+  // ---- boot -------------------------------------------------------------------
+  el.blurb.textContent = PV.presets.normal.blurb;
+  el.preset.value = 'normal';
+  if (el.waveHint) el.waveHint.textContent = 'last ' + rec.span.toFixed(0) + ' s';
+  computeGhost();
+  seedFromCycle();
+  requestAnimationFrame(frame);
+
+  root.PVLoop.app = { model: model, state: rec, opts: opts };
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/pv-loop-visualizer/js/model.js
+++ b/pv-loop-visualizer/js/model.js
@@ -1,0 +1,288 @@
+/*
+ * model.js — Closed-loop cardiovascular model for the BioGears PV-Loop Visualiser.
+ *
+ * A four-chamber (LV, RV, LA, RA) time-varying-elastance heart coupled to lumped
+ * systemic and pulmonary circulations through four diode-like valves. The model is
+ * written as a plain ES5-compatible script so it runs unchanged in the browser
+ * (attached to the global `PVLoop` namespace) and under Node.js for headless tuning.
+ *
+ * Physiology
+ * ----------
+ * Each cardiac chamber develops pressure through a time-varying elastance that
+ * blends an active end-systolic relation with a passive (exponential) end-diastolic
+ * relation, following Burkhoff/Smith minimal-model conventions:
+ *
+ *     P(V, t) = a(t)·Ees·(V − Vd) + (1 − a(t))·P0·(exp(λ·(V − V0)) − 1)
+ *
+ * The ventricular activation a(t) uses the same normalised double-Hill waveform that
+ * BioGears applies to its left/right heart elastance (Cardiovascular.cpp,
+ * CalculateHeartElastance): α1 = 0.303, α2 = 0.508, n1 = 1.32, n2 = 21.9. The default
+ * ventricular Ees values (LV 2.5, RV 1.1 mmHg/mL) match the BioGears configuration
+ * (LeftHeartElastanceMaximum 2.49, RightHeartElastanceMaximum 1.08). Atria use the
+ * same waveform shifted earlier in the cycle to reproduce the atrial "kick".
+ *
+ * Units: pressure mmHg, volume mL, time s, flow mL/s,
+ *        elastance mmHg/mL, compliance mL/mmHg, resistance mmHg·s/mL.
+ */
+(function (root) {
+  'use strict';
+
+  // ---- double-Hill ventricular activation (BioGears parameters) ---------------
+  var HILL = { a1: 0.303, a2: 0.508, n1: 1.32, n2: 21.9, maxShape: 0.598 };
+
+  function ventricularActivation(tau) {
+    // tau is the fraction of the cardiac cycle elapsed in [0, 1).
+    var g1 = Math.pow(tau / HILL.a1, HILL.n1);
+    var rising = g1 / (1 + g1);
+    var falling = 1 / (1 + Math.pow(tau / HILL.a2, HILL.n2));
+    var shape = (rising * falling) / HILL.maxShape;
+    return shape < 0 ? 0 : shape;
+  }
+
+  // Periodic Gaussian bump used for atrial activation (the atrial "kick").
+  function atrialActivation(tau, peak, width) {
+    var d = tau - peak;
+    if (d > 0.5) d -= 1;
+    if (d < -0.5) d += 1;
+    return Math.exp(-(d * d) / (2 * width * width));
+  }
+
+  // ---- default parameter set (healthy ~70 kg adult) ---------------------------
+  function defaultParams() {
+    return {
+      // Pacing & filling
+      heartRate: 72, // beats / min
+      bloodVolume: 5000, // total circulating volume, mL (preload reservoir)
+
+      // Chamber contractility — end-systolic elastance (mmHg/mL)
+      lvEes: 2.5, // BioGears LeftHeartElastanceMaximum = 2.49
+      rvEes: 0.95, // BioGears RightHeartElastanceMaximum = 1.08
+      laEes: 0.5,
+      raEes: 0.45,
+
+      // Passive (end-diastolic) stiffness scaling per chamber (× baseline λ)
+      lvStiffness: 1.0,
+      rvStiffness: 1.0,
+      laStiffness: 1.0,
+      raStiffness: 1.0,
+
+      // Afterload / vascular tone
+      systemicResistance: 1.05, // SVR, mmHg·s/mL
+      pulmonaryResistance: 0.11, // PVR, mmHg·s/mL
+      arterialCompliance: 1.2, // systemic arterial compliance, mL/mmHg
+      pulmonaryCompliance: 4.3, // pulmonary arterial compliance, mL/mmHg
+
+      // Valves: stenosis 0..1 (raises forward resistance),
+      //         regurgitation 0..1 (opens a backflow leak).
+      mitralStenosis: 0, mitralRegurg: 0,
+      aorticStenosis: 0, aorticRegurg: 0,
+      tricuspidStenosis: 0, tricuspidRegurg: 0,
+      pulmonicStenosis: 0, pulmonicRegurg: 0
+    };
+  }
+
+  // Fixed structural constants not exposed as primary sliders.
+  var STRUCT = {
+    // Unstressed volumes (mL)
+    v0: { lv: 8, rv: 12, la: 3, ra: 3, sa: 130, sv: 3320, pa: 40, pv: 200 },
+
+    // Venous / capacitance compliances (mL/mmHg) — arterial ones live in params.
+    cSv: 130.0, // systemic venous compliance
+    cPv: 14.0, // pulmonary venous compliance
+
+    // Non-valvular resistances (mmHg·s/mL)
+    rVc: 0.05, // systemic venous return (SV -> RA)
+    rPv: 0.012, // pulmonary venous (PV -> LA)
+
+    // Base valve forward resistance (mmHg·s/mL)
+    rValve: 0.0045,
+    rValveClosed: 1.0e6, // competent (closed) valve leak resistance
+
+    // ESPVR volume-axis intercepts Vd (mL)
+    vd: { lv: 5, rv: 8, la: 3, ra: 3 },
+
+    // Passive EDPVR: P0 (mmHg) and baseline lambda (1/mL); curve uses v0 above.
+    edp: {
+      lv: { p0: 0.5, lambda: 0.026 },
+      rv: { p0: 0.28, lambda: 0.011 },
+      la: { p0: 0.4, lambda: 0.055 },
+      ra: { p0: 0.35, lambda: 0.050 }
+    },
+
+    // Atrial activation timing (fraction of cycle) and width.
+    atrialPeak: 0.86,
+    atrialWidth: 0.045
+  };
+
+  function chamberPressure(kind, V, act, params) {
+    var vd = STRUCT.vd[kind];
+    var edp = STRUCT.edp[kind];
+    var ees;
+    var stiff;
+    switch (kind) {
+      case 'lv': ees = params.lvEes; stiff = params.lvStiffness; break;
+      case 'rv': ees = params.rvEes; stiff = params.rvStiffness; break;
+      case 'la': ees = params.laEes; stiff = params.laStiffness; break;
+      case 'ra': ees = params.raEes; stiff = params.raStiffness; break;
+      default: ees = 1; stiff = 1;
+    }
+    var pes = ees * (V - vd);
+    var lambda = edp.lambda * stiff;
+    var ped = edp.p0 * (Math.exp(lambda * (V - STRUCT.v0[kind])) - 1);
+    return act * pes + (1 - act) * ped;
+  }
+
+  // Valve flow (upstream -> downstream) as a smoothed diode.
+  function valveFlow(pUp, pDown, stenosis, regurg) {
+    var dp = pUp - pDown;
+    var rFwd = STRUCT.rValve * (1 + 55 * stenosis * stenosis);
+    if (dp >= 0) {
+      return dp / rFwd; // open, forward flow
+    }
+    // closed: tiny competent leak, or a regurgitant orifice when regurg > 0
+    var rBack = regurg > 1e-4
+      ? STRUCT.rValve * (1.2 / regurg)
+      : STRUCT.rValveClosed;
+    return dp / rBack; // negative (backflow)
+  }
+
+  function CVModel(params) {
+    this.params = Object.assign(defaultParams(), params || {});
+    this.t = 0; // absolute simulation time (s)
+    this.cycleTime = 0; // time within current cardiac cycle (s)
+    this.beat = 0; // completed-beat counter
+    this.dt = 2.0e-5; // integrator step (s)
+    this.reset();
+  }
+
+  CVModel.prototype.reset = function () {
+    // Initial volumes (mL) chosen close to steady state to speed convergence.
+    this.V = { lv: 120, rv: 130, la: 45, ra: 45, sa: 250, sv: 3300, pa: 110, pv: 230 };
+    this.t = 0;
+    this.cycleTime = 0;
+    this.beat = 0;
+    this.act = { lv: 0, rv: 0, la: 0, ra: 0 };
+    this.flow = { mv: 0, av: 0, tv: 0, pv: 0, sys: 0, vc: 0, pul: 0, pvv: 0 };
+    this.P = { lv: 0, rv: 0, la: 0, ra: 0, sa: 0, sv: 0, pa: 0, pv: 0 };
+    this._rescaleToBloodVolume();
+  };
+
+  // Adjust the venous reservoir so total volume matches params.bloodVolume.
+  CVModel.prototype._rescaleToBloodVolume = function () {
+    var total = 0, k;
+    for (k in this.V) total += this.V[k];
+    var delta = this.params.bloodVolume - total;
+    this.V.sv = Math.max(STRUCT.v0.sv * 0.4, this.V.sv + delta);
+  };
+
+  CVModel.prototype.setBloodVolume = function (mL) {
+    this.params.bloodVolume = mL;
+    this._rescaleToBloodVolume();
+  };
+
+  CVModel.prototype.period = function () {
+    return 60 / this.params.heartRate;
+  };
+
+  // Compute pressures & activations for the current state without integrating.
+  CVModel.prototype._evaluate = function () {
+    var p = this.params;
+    var T = this.period();
+    var tau = this.cycleTime / T;
+    var av = ventricularActivation(tau);
+    var aa = atrialActivation(tau, STRUCT.atrialPeak, STRUCT.atrialWidth);
+    this.act.lv = av; this.act.rv = av; this.act.la = aa; this.act.ra = aa;
+
+    var V = this.V, P = this.P;
+    P.lv = chamberPressure('lv', V.lv, av, p);
+    P.rv = chamberPressure('rv', V.rv, av, p);
+    P.la = chamberPressure('la', V.la, aa, p);
+    P.ra = chamberPressure('ra', V.ra, aa, p);
+    P.sa = (V.sa - STRUCT.v0.sa) / p.arterialCompliance;
+    P.sv = (V.sv - STRUCT.v0.sv) / STRUCT.cSv;
+    P.pa = (V.pa - STRUCT.v0.pa) / p.pulmonaryCompliance;
+    P.pv = (V.pv - STRUCT.v0.pv) / STRUCT.cPv;
+  };
+
+  // One explicit-Euler sub-step.
+  CVModel.prototype._step = function () {
+    var p = this.params, V = this.V, P = this.P, F = this.flow, dt = this.dt;
+    this._evaluate();
+
+    F.mv = valveFlow(P.la, P.lv, p.mitralStenosis, p.mitralRegurg);
+    F.av = valveFlow(P.lv, P.sa, p.aorticStenosis, p.aorticRegurg);
+    F.tv = valveFlow(P.ra, P.rv, p.tricuspidStenosis, p.tricuspidRegurg);
+    F.pv = valveFlow(P.rv, P.pa, p.pulmonicStenosis, p.pulmonicRegurg);
+
+    F.sys = (P.sa - P.sv) / p.systemicResistance;
+    F.vc = (P.sv - P.ra) / STRUCT.rVc;
+    F.pul = (P.pa - P.pv) / p.pulmonaryResistance;
+    F.pvv = (P.pv - P.la) / STRUCT.rPv;
+
+    V.lv += dt * (F.mv - F.av);
+    V.sa += dt * (F.av - F.sys);
+    V.sv += dt * (F.sys - F.vc);
+    V.ra += dt * (F.vc - F.tv);
+    V.rv += dt * (F.tv - F.pv);
+    V.pa += dt * (F.pv - F.pul);
+    V.pv += dt * (F.pul - F.pvv);
+    V.la += dt * (F.pvv - F.mv);
+
+    // Numerical floor: compartments cannot hold negative volume. This keeps
+    // severe states (e.g. profound hypovolemia) bounded and stable.
+    if (V.lv < 0.5) V.lv = 0.5;
+    if (V.rv < 0.5) V.rv = 0.5;
+    if (V.la < 0.5) V.la = 0.5;
+    if (V.ra < 0.5) V.ra = 0.5;
+    if (V.sa < STRUCT.v0.sa * 0.2) V.sa = STRUCT.v0.sa * 0.2;
+    if (V.pa < STRUCT.v0.pa * 0.2) V.pa = STRUCT.v0.pa * 0.2;
+    if (V.pv < STRUCT.v0.pv * 0.2) V.pv = STRUCT.v0.pv * 0.2;
+    if (V.sv < STRUCT.v0.sv * 0.2) V.sv = STRUCT.v0.sv * 0.2;
+
+    this.cycleTime += dt;
+    this.t += dt;
+    if (this.cycleTime >= this.period()) {
+      this.cycleTime -= this.period();
+      this.beat += 1;
+    }
+  };
+
+  // Advance the model by `seconds` of simulated time.
+  CVModel.prototype.advance = function (seconds) {
+    var n = Math.max(1, Math.round(seconds / this.dt));
+    for (var i = 0; i < n; i++) this._step();
+    this._evaluate();
+  };
+
+  // End-systolic (maximally active) pressure for a chamber at volume V — the ESPVR.
+  CVModel.prototype.endSystolicP = function (kind, V) {
+    return chamberPressure(kind, V, 1, this.params);
+  };
+
+  // End-diastolic (fully relaxed) pressure for a chamber at volume V — the EDPVR.
+  CVModel.prototype.endDiastolicP = function (kind, V) {
+    return chamberPressure(kind, V, 0, this.params);
+  };
+
+  // Run silently to a near-steady state (used on init / parameter changes).
+  CVModel.prototype.settle = function (beats) {
+    var target = this.beat + (beats || 12);
+    var guard = 0;
+    while (this.beat < target && guard < 5e7) {
+      this._step();
+      guard++;
+    }
+    this._evaluate();
+  };
+
+  root.PVLoop = root.PVLoop || {};
+  root.PVLoop.CVModel = CVModel;
+  root.PVLoop.defaultParams = defaultParams;
+  root.PVLoop.STRUCT = STRUCT;
+  root.PVLoop.ventricularActivation = ventricularActivation;
+  root.PVLoop.atrialActivation = atrialActivation;
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = root.PVLoop;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/pv-loop-visualizer/js/plots.js
+++ b/pv-loop-visualizer/js/plots.js
@@ -1,0 +1,418 @@
+/*
+ * plots.js — Canvas rendering for the PV-Loop Explorer.
+ * Three renderers: pressure–volume loops, scrolling Wiggers waveforms, and a
+ * live cardiac schematic. All renderers are pure functions of the supplied state
+ * and the current model, so the animation loop in app.js can simply re-call them.
+ */
+(function (root) {
+  'use strict';
+
+  var COL = {
+    lv: '#f43f5e', rv: '#38bdf8', la: '#f59e0b', ra: '#2dd4bf',
+    aorta: '#fb923c', pa: '#60a5fa',
+    grid: '#202a40', gridStrong: '#2c3a57', axis: '#3a4a6a',
+    text: '#8a98b4', textDim: '#5d6982', ghost: '#5b6b86'
+  };
+  var CHAMBERS = ['lv', 'rv', 'la', 'ra'];
+  var NAME = { lv: 'LV', rv: 'RV', la: 'LA', ra: 'RA' };
+
+  // Prepare a canvas backing store for the device pixel ratio; returns ctx + CSS size.
+  function fit(canvas) {
+    var dpr = window.devicePixelRatio || 1;
+    var rect = canvas.getBoundingClientRect();
+    var w = Math.max(1, Math.round(rect.width));
+    var h = Math.max(1, Math.round(rect.height));
+    if (canvas.width !== w * dpr || canvas.height !== h * dpr) {
+      canvas.width = w * dpr;
+      canvas.height = h * dpr;
+    }
+    var ctx = canvas.getContext('2d');
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    return { ctx: ctx, w: w, h: h };
+  }
+
+  function niceStep(range, targetTicks) {
+    var raw = range / targetTicks;
+    var mag = Math.pow(10, Math.floor(Math.log10(raw)));
+    var norm = raw / mag;
+    var step = norm >= 5 ? 5 : norm >= 2 ? 2 : 1;
+    return step * mag;
+  }
+
+  function roundUpTo(v, step) { return Math.ceil(v / step) * step; }
+
+  // ----------------------------------------------------------------- PV loops
+  function drawPVLoops(canvas, s) {
+    var f = fit(canvas), ctx = f.ctx, w = f.w, h = f.h;
+    ctx.clearRect(0, 0, w, h);
+
+    var ml = 56, mr = 16, mt = 14, mb = 40;
+    var pw = w - ml - mr, ph = h - mt - mb;
+    var vMax = s.axis.vMax, pMax = s.axis.pMax;
+
+    function X(v) { return ml + (v / vMax) * pw; }
+    function Y(p) { return mt + ph - (p / pMax) * ph; }
+
+    // grid
+    ctx.lineWidth = 1;
+    ctx.font = '11px Inter, sans-serif';
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'middle';
+    var pStep = niceStep(pMax, 6);
+    for (var p = 0; p <= pMax + 0.1; p += pStep) {
+      var yy = Y(p);
+      ctx.strokeStyle = p === 0 ? COL.axis : COL.grid;
+      ctx.beginPath(); ctx.moveTo(ml, yy); ctx.lineTo(ml + pw, yy); ctx.stroke();
+      ctx.fillStyle = COL.textDim;
+      ctx.fillText(String(Math.round(p)), ml - 8, yy);
+    }
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    var vStep = niceStep(vMax, 6);
+    for (var v = 0; v <= vMax + 0.1; v += vStep) {
+      var xx = X(v);
+      ctx.strokeStyle = v === 0 ? COL.axis : COL.grid;
+      ctx.beginPath(); ctx.moveTo(xx, mt); ctx.lineTo(xx, mt + ph); ctx.stroke();
+      ctx.fillStyle = COL.textDim;
+      ctx.fillText(String(Math.round(v)), xx, mt + ph + 6);
+    }
+
+    // axis titles
+    ctx.fillStyle = COL.text;
+    ctx.font = '12px Inter, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText('Volume  (mL)', ml + pw / 2, h - 16);
+    ctx.save();
+    ctx.translate(15, mt + ph / 2);
+    ctx.rotate(-Math.PI / 2);
+    ctx.fillText('Pressure  (mmHg)', 0, 0);
+    ctx.restore();
+
+    // reference ESPVR / EDPVR relations for each visible chamber
+    if (s.showRelations && s.model) {
+      for (var ci = 0; ci < CHAMBERS.length; ci++) {
+        var k = CHAMBERS[ci];
+        if (!s.visible[k]) continue;
+        ctx.strokeStyle = COL[k];
+        ctx.globalAlpha = 0.32;
+        ctx.setLineDash([5, 5]);
+        ctx.lineWidth = 1.4;
+        // EDPVR (passive)
+        ctx.beginPath();
+        var started = false;
+        for (var vv = 0; vv <= vMax; vv += vMax / 120) {
+          var pe = s.model.endDiastolicP(k, vv);
+          if (pe < 0) pe = 0;
+          if (pe > pMax * 1.3) break;
+          var px = X(vv), py = Y(pe);
+          if (!started) { ctx.moveTo(px, py); started = true; } else ctx.lineTo(px, py);
+        }
+        ctx.stroke();
+        // ESPVR (active end-systolic relation, straight line P = Ees·(V − Vd))
+        ctx.beginPath();
+        ctx.moveTo(X(0), Y(Math.max(0, s.model.endSystolicP(k, 0))));
+        ctx.lineTo(X(vMax), Y(Math.min(pMax * 1.2, s.model.endSystolicP(k, vMax))));
+        ctx.stroke();
+        ctx.setLineDash([]);
+        ctx.globalAlpha = 1;
+      }
+    }
+
+    // ghost (normal) comparison loops
+    if (s.ghost) {
+      for (var gi = 0; gi < CHAMBERS.length; gi++) {
+        var gk = CHAMBERS[gi];
+        if (!s.visible[gk] || !s.ghost[gk] || s.ghost[gk].length < 3) continue;
+        strokeLoop(ctx, s.ghost[gk], X, Y, COL.ghost, 1.3, 0.5, true);
+      }
+    }
+
+    // completed loops (filled) + live partial
+    for (var li = 0; li < CHAMBERS.length; li++) {
+      var c = CHAMBERS[li];
+      if (!s.visible[c]) continue;
+      var loop = s.loop[c];
+      if (loop && loop.length > 3) {
+        // fill
+        ctx.beginPath();
+        ctx.moveTo(X(loop[0].v), Y(loop[0].p));
+        for (var i = 1; i < loop.length; i++) ctx.lineTo(X(loop[i].v), Y(loop[i].p));
+        ctx.closePath();
+        ctx.fillStyle = hexA(COL[c], 0.10);
+        ctx.fill();
+        strokeLoop(ctx, loop, X, Y, COL[c], 2.0, 0.85, false);
+      }
+      // live partial (brighter leading trace)
+      var cur = s.cur[c];
+      if (cur && cur.length > 1) strokeLoop(ctx, cur, X, Y, COL[c], 2.4, 1, false);
+      // head marker
+      var head = s.head[c];
+      if (head) {
+        ctx.beginPath();
+        ctx.fillStyle = COL[c];
+        ctx.arc(X(head.v), Y(head.p), 4.2, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.strokeStyle = '#0a0e17';
+        ctx.lineWidth = 1.5;
+        ctx.stroke();
+      }
+    }
+
+    // legend
+    var lx = ml + 10, ly = mt + 8;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'middle';
+    ctx.font = '12px Inter, sans-serif';
+    for (var le = 0; le < CHAMBERS.length; le++) {
+      var lk = CHAMBERS[le];
+      if (!s.visible[lk]) continue;
+      ctx.fillStyle = COL[lk];
+      ctx.fillRect(lx, ly - 4, 14, 8);
+      ctx.fillStyle = COL.text;
+      ctx.fillText(NAME[lk], lx + 20, ly);
+      lx += 52;
+    }
+  }
+
+  function strokeLoop(ctx, pts, X, Y, color, width, alpha, dashed) {
+    ctx.save();
+    ctx.globalAlpha = alpha;
+    ctx.strokeStyle = color;
+    ctx.lineWidth = width;
+    ctx.lineJoin = 'round';
+    if (dashed) ctx.setLineDash([4, 4]);
+    ctx.beginPath();
+    ctx.moveTo(X(pts[0].v), Y(pts[0].p));
+    for (var i = 1; i < pts.length; i++) ctx.lineTo(X(pts[i].v), Y(pts[i].p));
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  function hexA(hex, a) {
+    var n = parseInt(hex.slice(1), 16);
+    return 'rgba(' + ((n >> 16) & 255) + ',' + ((n >> 8) & 255) + ',' + (n & 255) + ',' + a + ')';
+  }
+
+  // --------------------------------------------------------------- Wiggers
+  function drawWaves(canvas, s) {
+    var f = fit(canvas), ctx = f.ctx, w = f.w, h = f.h;
+    ctx.clearRect(0, 0, w, h);
+    var ml = 42, mr = 10, mt = 10, mb = 18, gap = 10;
+    var pw = w - ml - mr;
+    var pPlotH = (h - mt - mb - gap) * 0.66;
+    var vPlotH = (h - mt - mb - gap) * 0.34;
+    var pTop = mt, vTop = mt + pPlotH + gap;
+
+    var wave = s.wave;
+    if (!wave.length) return;
+    var t1 = s.tNow, t0 = t1 - s.span;
+    function X(t) { return ml + ((t - t0) / s.span) * pw; }
+
+    // pressure sub-plot
+    var pMax = s.pScale;
+    function YP(p) { return pTop + pPlotH - (p / pMax) * pPlotH; }
+    ctx.strokeStyle = COL.grid; ctx.lineWidth = 1;
+    ctx.font = '10px Inter, sans-serif'; ctx.fillStyle = COL.textDim;
+    ctx.textAlign = 'right'; ctx.textBaseline = 'middle';
+    var pst = niceStep(pMax, 4);
+    for (var p = 0; p <= pMax + 0.1; p += pst) {
+      ctx.strokeStyle = p === 0 ? COL.axis : COL.grid;
+      ctx.beginPath(); ctx.moveTo(ml, YP(p)); ctx.lineTo(ml + pw, YP(p)); ctx.stroke();
+      ctx.fillText(String(Math.round(p)), ml - 6, YP(p));
+    }
+
+    drawTrace(ctx, wave, 'pla', X, YP, COL.la, 1.6);
+    drawTrace(ctx, wave, 'psa', X, YP, COL.aorta, 1.8);
+    drawTrace(ctx, wave, 'plv', X, YP, COL.lv, 2.0);
+
+    // volume sub-plot
+    var vMax = s.vScale;
+    function YV(v) { return vTop + vPlotH - (v / vMax) * vPlotH; }
+    ctx.strokeStyle = COL.grid;
+    ctx.textAlign = 'right';
+    for (var vk = 0; vk <= vMax + 0.1; vk += niceStep(vMax, 2)) {
+      ctx.strokeStyle = vk === 0 ? COL.axis : COL.grid;
+      ctx.beginPath(); ctx.moveTo(ml, YV(vk)); ctx.lineTo(ml + pw, YV(vk)); ctx.stroke();
+      ctx.fillStyle = COL.textDim;
+      ctx.fillText(String(Math.round(vk)), ml - 6, YV(vk));
+    }
+    drawTrace(ctx, wave, 'vlv', X, YV, COL.lv, 1.8);
+
+    // labels
+    ctx.textAlign = 'left'; ctx.textBaseline = 'top';
+    ctx.font = '10.5px Inter, sans-serif';
+    ctx.fillStyle = COL.lv; ctx.fillText('LV P', ml + 4, pTop + 2);
+    ctx.fillStyle = COL.aorta; ctx.fillText('Aortic P', ml + 46, pTop + 2);
+    ctx.fillStyle = COL.la; ctx.fillText('LA P', ml + 110, pTop + 2);
+    ctx.fillStyle = COL.lv; ctx.fillText('LV volume (mL)', ml + 4, vTop + 2);
+  }
+
+  function drawTrace(ctx, wave, key, X, Y, color, width) {
+    ctx.strokeStyle = color; ctx.lineWidth = width; ctx.lineJoin = 'round';
+    ctx.beginPath();
+    var started = false;
+    for (var i = 0; i < wave.length; i++) {
+      var pt = wave[i];
+      var x = X(pt.t), y = Y(pt[key]);
+      if (!started) { ctx.moveTo(x, y); started = true; } else ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+  }
+
+  // --------------------------------------------------------------- Heart schematic
+  function drawHeart(canvas, s) {
+    var f = fit(canvas), ctx = f.ctx, w = f.w, h = f.h;
+    ctx.clearRect(0, 0, w, h);
+    var m = s.model;
+    var phase = s.phase || 0;
+
+    // layout: RA top-left, RV bottom-left, LA top-right, LV bottom-right
+    var cw = w * 0.27, chh = h * 0.32;
+    var gapx = w * 0.16, gapy = h * 0.10;
+    var leftx = w * 0.5 - gapx / 2 - cw;
+    var rightx = w * 0.5 + gapx / 2;
+    var topy = h * 0.16, boty = topy + chh + gapy;
+
+    var disp = {
+      ra: { x: leftx, y: topy, w: cw, h: chh, col: COL.ra, max: 95, label: 'RA' },
+      rv: { x: leftx, y: boty, w: cw, h: chh, col: COL.rv, max: 200, label: 'RV' },
+      la: { x: rightx, y: topy, w: cw, h: chh, col: COL.la, max: 95, label: 'LA' },
+      lv: { x: rightx, y: boty, w: cw, h: chh, col: COL.lv, max: 200, label: 'LV' }
+    };
+
+    // vessels behind chambers
+    // vena cava -> RA
+    vessel(ctx, leftx + cw * 0.5, topy - h * 0.13, leftx + cw * 0.5, topy, COL.rv, 'IVC/SVC');
+    // RV -> PA
+    vessel(ctx, leftx + cw * 0.5, boty + chh, leftx + cw * 0.5, boty + chh + h * 0.12, COL.pa, 'PA');
+    // pulm veins -> LA
+    vessel(ctx, rightx + cw * 0.5, topy - h * 0.13, rightx + cw * 0.5, topy, COL.la, 'Pulm v.');
+    // LV -> aorta
+    vessel(ctx, rightx + cw * 0.5, boty + chh, rightx + cw * 0.5, boty + chh + h * 0.12, COL.aorta, 'Aorta');
+
+    for (var k in disp) drawChamber(ctx, disp[k], m.V[k], m.P[k], phase);
+
+    // valves (open if forward flow > small threshold)
+    valve(ctx, disp.ra, disp.rv, m.flow.tv, 'TV', phase);   // tricuspid
+    valve(ctx, disp.la, disp.lv, m.flow.mv, 'MV', phase);   // mitral
+    valveVessel(ctx, disp.rv, m.flow.pv, 'PV', phase);      // pulmonic (to PA)
+    valveVessel(ctx, disp.lv, m.flow.av, 'AV', phase);      // aortic (to aorta)
+  }
+
+  function drawChamber(ctx, d, V, P, phase) {
+    var r = 12;
+    // shell
+    roundRect(ctx, d.x, d.y, d.w, d.h, r);
+    ctx.fillStyle = 'rgba(255,255,255,0.03)';
+    ctx.fill();
+    // fill level by volume
+    var frac = Math.max(0.04, Math.min(1, V / d.max));
+    var fh = d.h * frac;
+    ctx.save();
+    roundRect(ctx, d.x, d.y, d.w, d.h, r);
+    ctx.clip();
+    var grad = ctx.createLinearGradient(0, d.y + d.h - fh, 0, d.y + d.h);
+    grad.addColorStop(0, hexA(d.col, 0.85));
+    grad.addColorStop(1, hexA(d.col, 0.45));
+    ctx.fillStyle = grad;
+    ctx.fillRect(d.x, d.y + d.h - fh, d.w, fh);
+    ctx.restore();
+    // outline
+    roundRect(ctx, d.x, d.y, d.w, d.h, r);
+    ctx.strokeStyle = hexA(d.col, 0.9);
+    ctx.lineWidth = 1.6;
+    ctx.stroke();
+    // labels
+    ctx.fillStyle = '#fff';
+    ctx.font = '600 15px Inter, sans-serif';
+    ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+    ctx.fillText(d.label, d.x + d.w / 2, d.y + 16);
+    ctx.font = '11px Inter, sans-serif';
+    ctx.fillStyle = 'rgba(255,255,255,0.92)';
+    ctx.fillText(Math.round(P) + ' mmHg', d.x + d.w / 2, d.y + d.h / 2);
+    ctx.fillStyle = 'rgba(255,255,255,0.72)';
+    ctx.fillText(Math.round(V) + ' mL', d.x + d.w / 2, d.y + d.h / 2 + 15);
+  }
+
+  function valve(ctx, a, b, flow, label, phase) {
+    // AV valve sits in the gap between the same-side atrium (a) and ventricle (b)
+    var cx = a.x + a.w / 2;
+    var y = (a.y + a.h + b.y) / 2;
+    var open = flow > 1;
+    ctx.strokeStyle = open ? '#34d399' : '#41506e';
+    ctx.lineWidth = 3;
+    ctx.beginPath();
+    if (open) {
+      ctx.moveTo(cx - 13, y); ctx.lineTo(cx - 5, y - 9);
+      ctx.moveTo(cx + 13, y); ctx.lineTo(cx + 5, y - 9);
+    } else {
+      ctx.moveTo(cx - 13, y - 7); ctx.lineTo(cx, y + 2);
+      ctx.moveTo(cx + 13, y - 7); ctx.lineTo(cx, y + 2);
+    }
+    ctx.stroke();
+    if (open) drawFlowArrow(ctx, cx, a.y + a.h, cx, b.y, '#34d399', phase, Math.min(1, flow / 400));
+    ctx.fillStyle = COL.textDim; ctx.font = '9px Inter'; ctx.textAlign = 'left'; ctx.textBaseline = 'middle';
+    ctx.fillText(label, cx + 16, y);
+  }
+
+  function valveVessel(ctx, d, flow, label, phase) {
+    var cx = d.x + d.w / 2;
+    var y = d.y + d.h + 6;
+    var open = flow > 1;
+    ctx.strokeStyle = open ? '#34d399' : '#41506e';
+    ctx.lineWidth = 3;
+    ctx.beginPath();
+    if (open) {
+      ctx.moveTo(cx - 11, y); ctx.lineTo(cx - 4, y + 8);
+      ctx.moveTo(cx + 11, y); ctx.lineTo(cx + 4, y + 8);
+    } else {
+      ctx.moveTo(cx - 11, y + 8); ctx.lineTo(cx, y);
+      ctx.moveTo(cx + 11, y + 8); ctx.lineTo(cx, y);
+    }
+    ctx.stroke();
+    ctx.fillStyle = COL.textDim; ctx.font = '9px Inter'; ctx.textAlign = 'left'; ctx.textBaseline = 'middle';
+    ctx.fillText(label, cx + 14, y + 4);
+  }
+
+  function vessel(ctx, x1, y1, x2, y2, color, label) {
+    ctx.strokeStyle = hexA(color, 0.5);
+    ctx.lineWidth = 10;
+    ctx.lineCap = 'round';
+    ctx.beginPath(); ctx.moveTo(x1, y1); ctx.lineTo(x2, y2); ctx.stroke();
+    ctx.lineCap = 'butt';
+    ctx.fillStyle = COL.textDim; ctx.font = '9px Inter';
+    ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+    var labelY = y1 < y2 ? y1 - 7 : y1 + 7; // place label on the outer end of the vessel
+    ctx.fillText(label, x1, labelY);
+  }
+
+  function drawFlowArrow(ctx, x1, y1, x2, y2, color, phase, intensity) {
+    var n = 3;
+    ctx.fillStyle = hexA(color, 0.35 + 0.5 * intensity);
+    for (var i = 0; i < n; i++) {
+      var t = ((phase + i / n) % 1);
+      var x = x1 + (x2 - x1) * t, y = y1 + (y2 - y1) * t;
+      ctx.beginPath();
+      ctx.arc(x, y, 2.2, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  function roundRect(ctx, x, y, w, h, r) {
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.arcTo(x + w, y, x + w, y + h, r);
+    ctx.arcTo(x + w, y + h, x, y + h, r);
+    ctx.arcTo(x, y + h, x, y, r);
+    ctx.arcTo(x, y, x + w, y, r);
+    ctx.closePath();
+  }
+
+  root.PVLoop = root.PVLoop || {};
+  root.PVLoop.plots = {
+    drawPVLoops: drawPVLoops,
+    drawWaves: drawWaves,
+    drawHeart: drawHeart,
+    COL: COL
+  };
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/pv-loop-visualizer/js/presets.js
+++ b/pv-loop-visualizer/js/presets.js
@@ -1,0 +1,118 @@
+/*
+ * presets.js — Physiological and pathological scenarios for the PV-loop visualiser.
+ * Each preset supplies parameter overrides on top of the healthy defaults defined
+ * in model.js. Values were tuned against the closed-loop model (see tools/tune.js)
+ * to reproduce the characteristic loop morphology of each condition.
+ */
+(function (root) {
+  'use strict';
+
+  var presets = {
+    normal: {
+      label: 'Normal',
+      group: 'Physiology',
+      blurb: 'Healthy resting adult. LV ~120/8 mmHg, EF ~60%, CO ~5 L/min.',
+      params: {}
+    },
+
+    exercise: {
+      label: 'Exercise',
+      group: 'Physiology',
+      blurb: 'Sympathetic drive: faster rate, stronger contraction, vasodilated muscle beds. CO rises sharply.',
+      params: {
+        heartRate: 145, lvEes: 4.0, rvEes: 1.7, laEes: 0.8, raEes: 0.7,
+        systemicResistance: 0.55, pulmonaryResistance: 0.08, bloodVolume: 5200
+      }
+    },
+
+    hfref: {
+      label: 'Systolic HF (HFrEF)',
+      group: 'Failure',
+      blurb: 'Dilated, weak LV: low contractility, volume overload, compensatory tachycardia. EF falls, loop shifts right.',
+      params: {
+        lvEes: 0.7, rvEes: 0.8, lvStiffness: 0.8, heartRate: 95,
+        systemicResistance: 1.35, bloodVolume: 5600
+      }
+    },
+
+    hfpef: {
+      label: 'Diastolic HF (HFpEF)',
+      group: 'Failure',
+      blurb: 'Stiff, non-compliant LV: preserved EF but high filling pressures and a tall, steep diastolic limb.',
+      params: {
+        lvStiffness: 2.2, lvEes: 2.7, laStiffness: 1.3,
+        heartRate: 82, bloodVolume: 5300
+      }
+    },
+
+    hypertension: {
+      label: 'Hypertension',
+      group: 'Loading',
+      blurb: 'High afterload and stiff arteries. LV generates higher pressure; the loop grows taller and narrower.',
+      params: {
+        systemicResistance: 1.55, arterialCompliance: 0.85, lvEes: 3.0, bloodVolume: 5100
+      }
+    },
+
+    hemorrhage: {
+      label: 'Hemorrhage / Hypovolemia',
+      group: 'Loading',
+      blurb: 'Acute blood loss reduces preload. Loops shrink and shift left, CO and pressures fall, reflex tachycardia.',
+      params: {
+        bloodVolume: 4350, heartRate: 112, systemicResistance: 1.35, lvEes: 2.7
+      }
+    },
+
+    aorticStenosis: {
+      label: 'Aortic Stenosis',
+      group: 'Valves',
+      blurb: 'Narrowed aortic valve: large LV–aortic systolic gradient and a tall, square LV loop from concentric hypertrophy.',
+      params: {
+        aorticStenosis: 0.86, lvEes: 4.5, lvStiffness: 1.6, bloodVolume: 5200
+      }
+    },
+
+    aorticRegurg: {
+      label: 'Aortic Regurgitation',
+      group: 'Valves',
+      blurb: 'Leaky aortic valve: diastolic backflow into the LV. Wide pulse pressure, large EDV, loss of isovolumic relaxation.',
+      params: {
+        aorticRegurg: 0.55, bloodVolume: 5400, arterialCompliance: 1.7, lvEes: 2.2
+      }
+    },
+
+    mitralRegurg: {
+      label: 'Mitral Regurgitation',
+      group: 'Valves',
+      blurb: 'Leaky mitral valve: systolic backflow into the LA. Giant v-wave, volume-overloaded LV, no true isovolumic phase.',
+      params: {
+        mitralRegurg: 0.52, bloodVolume: 5300, lvEes: 2.1, laStiffness: 1.2
+      }
+    },
+
+    mitralStenosis: {
+      label: 'Mitral Stenosis',
+      group: 'Valves',
+      blurb: 'Narrowed mitral valve impedes LV filling. High LA pressure, small underfilled LV, reduced CO.',
+      params: {
+        mitralStenosis: 0.8, bloodVolume: 5400, heartRate: 88, laEes: 0.6
+      }
+    },
+
+    pulmHypertension: {
+      label: 'Pulmonary Hypertension',
+      group: 'Loading',
+      blurb: 'High pulmonary vascular resistance loads the RV. RV pressure and volume rise; the RV loop enlarges markedly.',
+      params: {
+        pulmonaryResistance: 0.42, rvEes: 1.9, rvStiffness: 1.4, bloodVolume: 5300
+      }
+    }
+  };
+
+  root.PVLoop = root.PVLoop || {};
+  root.PVLoop.presets = presets;
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { presets: presets };
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/pv-loop-visualizer/js/ui.js
+++ b/pv-loop-visualizer/js/ui.js
@@ -1,0 +1,222 @@
+/*
+ * ui.js — Builds the control panel (sliders, presets, chamber toggles) and the
+ * hemodynamics metrics cards. UI widgets are data-driven from SLIDER_GROUPS and
+ * communicate back to app.js purely through callbacks.
+ */
+(function (root) {
+  'use strict';
+
+  var pct = function (v) { return Math.round(v * 100) + '%'; };
+
+  var SLIDER_GROUPS = [
+    {
+      title: 'Pacing & Preload', open: true, items: [
+        { key: 'heartRate', label: 'Heart rate', min: 40, max: 180, step: 1, unit: 'bpm' },
+        { key: 'bloodVolume', label: 'Blood volume', min: 3500, max: 6500, step: 50, unit: 'mL' }
+      ]
+    },
+    {
+      title: 'Contractility (Ees)', open: true, items: [
+        { key: 'lvEes', label: 'LV contractility', min: 0.2, max: 5, step: 0.05, unit: 'mmHg/mL', dec: 2 },
+        { key: 'rvEes', label: 'RV contractility', min: 0.1, max: 3, step: 0.05, unit: 'mmHg/mL', dec: 2 },
+        { key: 'laEes', label: 'LA contractility', min: 0.1, max: 1.5, step: 0.05, unit: 'mmHg/mL', dec: 2 },
+        { key: 'raEes', label: 'RA contractility', min: 0.1, max: 1.5, step: 0.05, unit: 'mmHg/mL', dec: 2 }
+      ]
+    },
+    {
+      title: 'Diastolic Stiffness', open: false, items: [
+        { key: 'lvStiffness', label: 'LV stiffness', min: 0.4, max: 4, step: 0.05, unit: '×', dec: 2 },
+        { key: 'rvStiffness', label: 'RV stiffness', min: 0.4, max: 4, step: 0.05, unit: '×', dec: 2 },
+        { key: 'laStiffness', label: 'LA stiffness', min: 0.4, max: 4, step: 0.05, unit: '×', dec: 2 },
+        { key: 'raStiffness', label: 'RA stiffness', min: 0.4, max: 4, step: 0.05, unit: '×', dec: 2 }
+      ]
+    },
+    {
+      title: 'Afterload & Vasculature', open: true, items: [
+        { key: 'systemicResistance', label: 'Systemic resistance (SVR)', min: 0.3, max: 2.5, step: 0.05, unit: 'mmHg·s/mL', dec: 2 },
+        { key: 'pulmonaryResistance', label: 'Pulmonary resistance (PVR)', min: 0.03, max: 0.6, step: 0.01, unit: 'mmHg·s/mL', dec: 2 },
+        { key: 'arterialCompliance', label: 'Arterial compliance', min: 0.4, max: 3, step: 0.05, unit: 'mL/mmHg', dec: 2 },
+        { key: 'pulmonaryCompliance', label: 'Pulmonary compliance', min: 1, max: 10, step: 0.1, unit: 'mL/mmHg', dec: 1 }
+      ]
+    },
+    {
+      title: 'Valves — Stenosis / Regurgitation', open: false, items: [
+        { key: 'mitralStenosis', label: 'Mitral stenosis', min: 0, max: 1, step: 0.01, fmt: pct },
+        { key: 'mitralRegurg', label: 'Mitral regurgitation', min: 0, max: 1, step: 0.01, fmt: pct },
+        { key: 'aorticStenosis', label: 'Aortic stenosis', min: 0, max: 1, step: 0.01, fmt: pct },
+        { key: 'aorticRegurg', label: 'Aortic regurgitation', min: 0, max: 1, step: 0.01, fmt: pct },
+        { key: 'tricuspidStenosis', label: 'Tricuspid stenosis', min: 0, max: 1, step: 0.01, fmt: pct },
+        { key: 'tricuspidRegurg', label: 'Tricuspid regurgitation', min: 0, max: 1, step: 0.01, fmt: pct },
+        { key: 'pulmonicStenosis', label: 'Pulmonic stenosis', min: 0, max: 1, step: 0.01, fmt: pct },
+        { key: 'pulmonicRegurg', label: 'Pulmonic regurgitation', min: 0, max: 1, step: 0.01, fmt: pct }
+      ]
+    }
+  ];
+
+  function fmtValue(item, v) {
+    if (item.fmt) return item.fmt(v);
+    var num = item.dec != null ? v.toFixed(item.dec) : String(Math.round(v));
+    return num + (item.unit ? ' <span class="unit">' + item.unit + '</span>' : '');
+  }
+
+  function buildControls(container, params, baseline, onChange) {
+    container.innerHTML = '';
+    var refs = {};
+    SLIDER_GROUPS.forEach(function (group) {
+      var details = document.createElement('details');
+      details.className = 'ctl-group';
+      if (group.open) details.open = true;
+      var summary = document.createElement('summary');
+      summary.textContent = group.title;
+      details.appendChild(summary);
+      var body = document.createElement('div');
+      body.className = 'group-body';
+      details.appendChild(body);
+
+      group.items.forEach(function (item) {
+        var wrap = document.createElement('div');
+        wrap.className = 'slider';
+        var row = document.createElement('div');
+        row.className = 'row';
+        var label = document.createElement('label');
+        label.textContent = item.label;
+        var val = document.createElement('div');
+        val.className = 'val';
+        val.innerHTML = fmtValue(item, params[item.key]);
+        row.appendChild(label); row.appendChild(val);
+
+        var input = document.createElement('input');
+        input.type = 'range';
+        input.min = item.min; input.max = item.max; input.step = item.step;
+        input.value = params[item.key];
+
+        input.addEventListener('input', function () {
+          var v = parseFloat(input.value);
+          val.innerHTML = fmtValue(item, v);
+          markChanged(input, v, baseline[item.key]);
+          onChange(item.key, v);
+        });
+
+        wrap.appendChild(row); wrap.appendChild(input);
+        body.appendChild(wrap);
+        refs[item.key] = { input: input, val: val, item: item };
+      });
+      container.appendChild(details);
+    });
+
+    function markChanged(input, v, base) {
+      if (base != null && Math.abs(v - base) > 1e-9) input.classList.add('mod-changed');
+      else input.classList.remove('mod-changed');
+    }
+
+    return {
+      refresh: function (p, base) {
+        Object.keys(refs).forEach(function (key) {
+          var r = refs[key];
+          r.input.value = p[key];
+          r.val.innerHTML = fmtValue(r.item, p[key]);
+          markChanged(r.input, p[key], base[key]);
+        });
+      }
+    };
+  }
+
+  function buildChamberToggles(container, visible, onToggle) {
+    container.innerHTML = '';
+    var order = [['lv', 'LV'], ['rv', 'RV'], ['la', 'LA'], ['ra', 'RA']];
+    order.forEach(function (pair) {
+      var key = pair[0];
+      var chip = document.createElement('button');
+      chip.className = 'chip' + (visible[key] ? ' on' : '');
+      chip.setAttribute('data-ch', key);
+      chip.innerHTML = '<span class="dot"></span>' + pair[1];
+      chip.addEventListener('click', function () {
+        visible[key] = !visible[key];
+        chip.classList.toggle('on', visible[key]);
+        onToggle(key, visible[key]);
+      });
+      container.appendChild(chip);
+    });
+  }
+
+  function buildPresetSelect(select, presets, onSelect) {
+    select.innerHTML = '';
+    var groups = {};
+    Object.keys(presets).forEach(function (key) {
+      var g = presets[key].group || 'Other';
+      (groups[g] = groups[g] || []).push(key);
+    });
+    Object.keys(groups).forEach(function (g) {
+      var og = document.createElement('optgroup');
+      og.label = g;
+      groups[g].forEach(function (key) {
+        var opt = document.createElement('option');
+        opt.value = key;
+        opt.textContent = presets[key].label;
+        og.appendChild(opt);
+      });
+      select.appendChild(og);
+    });
+    select.addEventListener('change', function () { onSelect(select.value); });
+  }
+
+  // ---- metrics ----------------------------------------------------------------
+  function flag(value, lo, hi) {
+    if (value < lo) return 'flag-bad';
+    if (value > hi) return 'flag-bad';
+    return '';
+  }
+
+  function row(label, value, cls) {
+    return '<div class="metric-row"><span>' + label + '</span><span class="' + (cls || '') + '">' + value + '</span></div>';
+  }
+
+  function card(title, color, rowsHtml) {
+    return '<div class="metric-card"><h3><span class="dot" style="background:' + color + '"></span>' + title + '</h3>' + rowsHtml + '</div>';
+  }
+
+  function renderMetrics(container, m) {
+    if (!m || !m.lv) { container.innerHTML = '<p class="hint">Collecting first beat…</p>'; return; }
+    var C = root.PVLoop.plots.COL;
+    var html = '';
+    html += card('Left Ventricle', C.lv,
+      row('EDV', Math.round(m.lv.edv) + ' mL') +
+      row('ESV', Math.round(m.lv.esv) + ' mL') +
+      row('Stroke vol', Math.round(m.lv.sv) + ' mL') +
+      row('Ejection fraction', Math.round(m.lv.ef) + ' %', m.lv.ef < 50 ? 'flag-bad' : (m.lv.ef < 55 ? 'flag-warn' : 'flag-good')) +
+      row('Peak pressure', Math.round(m.lv.pMax) + ' mmHg'));
+    html += card('Right Ventricle', C.rv,
+      row('EDV', Math.round(m.rv.edv) + ' mL') +
+      row('ESV', Math.round(m.rv.esv) + ' mL') +
+      row('Stroke vol', Math.round(m.rv.sv) + ' mL') +
+      row('Ejection fraction', Math.round(m.rv.ef) + ' %') +
+      row('Peak pressure', Math.round(m.rv.pMax) + ' mmHg'));
+    html += card('Left Atrium', C.la,
+      row('Volume', Math.round(m.la.esv) + '–' + Math.round(m.la.edv) + ' mL') +
+      row('Mean pressure', Math.round(m.la.pMean) + ' mmHg', m.la.pMean > 18 ? 'flag-bad' : (m.la.pMean > 14 ? 'flag-warn' : '')) +
+      row('Peak (v-wave)', Math.round(m.la.pMax) + ' mmHg'));
+    html += card('Right Atrium', C.ra,
+      row('Volume', Math.round(m.ra.esv) + '–' + Math.round(m.ra.edv) + ' mL') +
+      row('Mean pressure', Math.round(m.ra.pMean) + ' mmHg', m.ra.pMean > 8 ? 'flag-warn' : '') +
+      row('Peak pressure', Math.round(m.ra.pMax) + ' mmHg'));
+    html += card('Systemic', C.aorta,
+      row('Arterial pressure', Math.round(m.sys.sbp) + '/' + Math.round(m.sys.dbp) + ' mmHg') +
+      row('Mean (MAP)', Math.round(m.sys.map) + ' mmHg', m.sys.map < 65 ? 'flag-bad' : (m.sys.map > 110 ? 'flag-warn' : 'flag-good')) +
+      row('Cardiac output', m.co.toFixed(1) + ' L/min', m.co < 4 ? 'flag-bad' : 'flag-good') +
+      row('Heart rate', Math.round(m.hr) + ' bpm'));
+    html += card('Pulmonary', C.pa,
+      row('PA pressure', Math.round(m.pulm.pas) + '/' + Math.round(m.pulm.pad) + ' mmHg') +
+      row('Mean PAP', Math.round(m.pulm.pamean) + ' mmHg', m.pulm.pamean > 20 ? 'flag-warn' : '') +
+      row('Cardiac index', (m.co / 1.9).toFixed(1) + ' L/min/m²'));
+    container.innerHTML = html;
+  }
+
+  root.PVLoop = root.PVLoop || {};
+  root.PVLoop.ui = {
+    buildControls: buildControls,
+    buildChamberToggles: buildChamberToggles,
+    buildPresetSelect: buildPresetSelect,
+    renderMetrics: renderMetrics,
+    SLIDER_GROUPS: SLIDER_GROUPS
+  };
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/pv-loop-visualizer/styles.css
+++ b/pv-loop-visualizer/styles.css
@@ -1,0 +1,245 @@
+:root {
+  --bg: #0a0e17;
+  --bg-soft: #121826;
+  --panel: #151c2c;
+  --panel-2: #1b2333;
+  --line: #2a3650;
+  --line-soft: #212b40;
+  --text: #e8edf6;
+  --text-dim: #9aa7bf;
+  --text-faint: #66728c;
+  --accent: #38bdf8;
+  --accent-2: #818cf8;
+  --good: #34d399;
+  --warn: #fbbf24;
+  --bad: #fb7185;
+
+  /* chamber colours */
+  --lv: #f43f5e;
+  --rv: #38bdf8;
+  --la: #f59e0b;
+  --ra: #2dd4bf;
+  --aorta: #fb923c;
+  --pa: #60a5fa;
+
+  --radius: 12px;
+  --shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background:
+    radial-gradient(1200px 600px at 80% -10%, rgba(56, 189, 248, 0.08), transparent 60%),
+    radial-gradient(900px 500px at -10% 10%, rgba(129, 140, 248, 0.07), transparent 55%),
+    var(--bg);
+  color: var(--text);
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  font-size: 14px;
+  line-height: 1.45;
+  -webkit-font-smoothing: antialiased;
+}
+
+h1, h2, h3 { margin: 0; font-weight: 650; letter-spacing: -0.01em; }
+code { font-family: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.85em; color: var(--accent); }
+
+/* ---------------- header ---------------- */
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 16px 22px;
+  flex-wrap: wrap;
+}
+.brand { display: flex; align-items: center; gap: 14px; }
+.brand-mark {
+  display: grid; place-items: center;
+  width: 46px; height: 46px; border-radius: 12px;
+  color: #fff;
+  background: linear-gradient(135deg, var(--lv), var(--accent-2));
+  box-shadow: 0 6px 18px rgba(244, 63, 94, 0.35);
+}
+.brand-text h1 { font-size: 20px; }
+.brand-text p { margin: 2px 0 0; color: var(--text-dim); font-size: 12.5px; }
+
+.header-controls { display: flex; align-items: flex-end; gap: 16px; flex-wrap: wrap; }
+.preset-field { display: flex; flex-direction: column; gap: 4px; }
+.preset-field span { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-faint); }
+#presetSelect {
+  background: var(--panel-2); color: var(--text);
+  border: 1px solid var(--line); border-radius: 9px;
+  padding: 9px 12px; font-size: 13.5px; min-width: 230px; cursor: pointer;
+}
+#presetSelect:focus { outline: 2px solid var(--accent); outline-offset: 1px; }
+optgroup { color: var(--text-dim); }
+
+.transport { display: flex; gap: 8px; }
+.btn {
+  background: var(--panel-2); color: var(--text);
+  border: 1px solid var(--line); border-radius: 9px;
+  padding: 9px 14px; font-size: 13px; font-weight: 550; cursor: pointer;
+  transition: background .15s, border-color .15s, transform .05s;
+}
+.btn:hover { background: #232c40; border-color: #3a4866; }
+.btn:active { transform: translateY(1px); }
+.btn-primary { background: linear-gradient(135deg, var(--accent), var(--accent-2)); border: none; color: #04121c; }
+.btn-primary:hover { filter: brightness(1.07); }
+
+.scenario-blurb {
+  margin: -4px 22px 8px; padding: 10px 14px;
+  background: var(--panel); border: 1px solid var(--line-soft);
+  border-left: 3px solid var(--accent);
+  border-radius: 9px; color: var(--text-dim); font-size: 13px; max-width: 100%;
+}
+
+/* ---------------- layout ---------------- */
+.layout {
+  display: grid;
+  gap: 14px;
+  padding: 0 22px 18px;
+  grid-template-columns: 320px minmax(440px, 1.5fr) minmax(330px, 1fr);
+  grid-template-areas:
+    "controls pv wave"
+    "controls pv heart"
+    "controls metrics metrics";
+  align-items: stretch;
+}
+.controls { grid-area: controls; }
+.pv-panel { grid-area: pv; }
+.wave-panel { grid-area: wave; }
+.heart-panel { grid-area: heart; }
+.metrics-panel { grid-area: metrics; }
+
+.panel {
+  background: linear-gradient(180deg, var(--panel), var(--bg-soft));
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 14px 16px;
+  display: flex; flex-direction: column; min-width: 0;
+}
+.panel-head {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 10px; margin-bottom: 12px; flex-wrap: wrap;
+}
+.panel-head h2 { font-size: 14px; color: var(--text); }
+.hint { font-size: 11.5px; color: var(--text-faint); }
+
+/* ---------------- canvases ---------------- */
+.canvas-wrap { position: relative; width: 100%; }
+.pv-wrap { aspect-ratio: 1 / 1; }
+.wave-wrap { height: 230px; }
+.heart-wrap { height: 300px; }
+canvas { width: 100%; height: 100%; display: block; border-radius: 8px; }
+
+.pv-options {
+  display: flex; gap: 16px; flex-wrap: wrap;
+  margin-top: 12px; padding-top: 10px; border-top: 1px solid var(--line-soft);
+}
+.check { display: flex; align-items: center; gap: 7px; font-size: 12.5px; color: var(--text-dim); cursor: pointer; }
+.check input { accent-color: var(--accent); width: 15px; height: 15px; }
+
+/* ---------------- chamber toggles ---------------- */
+.chamber-toggles { display: flex; gap: 6px; flex-wrap: wrap; }
+.chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 5px 11px; border-radius: 999px; cursor: pointer;
+  font-size: 12px; font-weight: 600; user-select: none;
+  border: 1px solid var(--line); background: var(--panel-2); color: var(--text-dim);
+  transition: all .12s;
+}
+.chip .dot { width: 9px; height: 9px; border-radius: 50%; background: currentColor; }
+.chip.on { color: #06101c; }
+.chip[data-ch="lv"].on { background: var(--lv); border-color: var(--lv); }
+.chip[data-ch="rv"].on { background: var(--rv); border-color: var(--rv); }
+.chip[data-ch="la"].on { background: var(--la); border-color: var(--la); }
+.chip[data-ch="ra"].on { background: var(--ra); border-color: var(--ra); }
+.chip.on .dot { background: rgba(6, 16, 28, 0.7); }
+
+/* ---------------- controls / sliders ---------------- */
+#controlGroups { overflow-y: auto; padding-right: 4px; }
+.ctl-group { margin-bottom: 6px; border: 1px solid var(--line-soft); border-radius: 10px; overflow: hidden; }
+.ctl-group > summary {
+  list-style: none; cursor: pointer; padding: 10px 12px;
+  font-size: 12px; font-weight: 650; text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--text-dim); background: var(--panel-2);
+  display: flex; align-items: center; justify-content: space-between;
+}
+.ctl-group > summary::-webkit-details-marker { display: none; }
+.ctl-group > summary::after { content: "▾"; color: var(--text-faint); transition: transform .15s; }
+.ctl-group[open] > summary::after { transform: rotate(180deg); }
+.ctl-group .group-body { padding: 10px 12px 12px; }
+
+.slider {
+  margin-bottom: 13px;
+}
+.slider:last-child { margin-bottom: 2px; }
+.slider .row { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 5px; }
+.slider label { font-size: 12.5px; color: var(--text); }
+.slider .val { font-size: 12.5px; font-weight: 650; color: var(--accent); font-variant-numeric: tabular-nums; }
+.slider .val .unit { color: var(--text-faint); font-weight: 500; font-size: 11px; margin-left: 2px; }
+input[type="range"] {
+  -webkit-appearance: none; appearance: none; width: 100%; height: 5px;
+  border-radius: 4px; background: var(--line); outline: none; cursor: pointer;
+}
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none; appearance: none; width: 16px; height: 16px; border-radius: 50%;
+  background: var(--accent); border: 2px solid #0a0e17; box-shadow: 0 0 0 1px var(--accent);
+}
+input[type="range"]::-moz-range-thumb {
+  width: 16px; height: 16px; border-radius: 50%;
+  background: var(--accent); border: 2px solid #0a0e17;
+}
+input[type="range"].mod-changed::-webkit-slider-thumb { background: var(--warn); box-shadow: 0 0 0 1px var(--warn); }
+
+/* ---------------- metrics ---------------- */
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 10px;
+}
+.metric-card {
+  background: var(--panel-2); border: 1px solid var(--line-soft);
+  border-radius: 10px; padding: 11px 13px;
+}
+.metric-card h3 {
+  font-size: 11px; text-transform: uppercase; letter-spacing: 0.07em;
+  color: var(--text-faint); margin-bottom: 8px;
+  display: flex; align-items: center; gap: 7px;
+}
+.metric-card h3 .dot { width: 9px; height: 9px; border-radius: 50%; }
+.metric-row { display: flex; justify-content: space-between; font-size: 12.5px; padding: 1.5px 0; }
+.metric-row span:first-child { color: var(--text-dim); }
+.metric-row span:last-child { font-weight: 600; font-variant-numeric: tabular-nums; }
+.metric-row .flag-bad { color: var(--bad); }
+.metric-row .flag-warn { color: var(--warn); }
+.metric-row .flag-good { color: var(--good); }
+
+/* ---------------- footer ---------------- */
+.app-footer {
+  display: flex; justify-content: space-between; gap: 16px; flex-wrap: wrap;
+  padding: 14px 22px 22px; color: var(--text-faint); font-size: 11.5px;
+}
+.disclaimer { color: var(--warn); opacity: 0.8; }
+
+/* ---------------- responsive ---------------- */
+@media (max-width: 1180px) {
+  .layout {
+    grid-template-columns: 300px 1fr;
+    grid-template-areas:
+      "controls pv"
+      "controls wave"
+      "controls heart"
+      "controls metrics";
+  }
+}
+@media (max-width: 820px) {
+  .layout {
+    grid-template-columns: 1fr;
+    grid-template-areas: "controls" "pv" "wave" "heart" "metrics";
+  }
+  #controlGroups { max-height: none; }
+}

--- a/pv-loop-visualizer/tools/tune.js
+++ b/pv-loop-visualizer/tools/tune.js
@@ -1,0 +1,82 @@
+/* Headless tuning / validation harness for the cardiovascular model.
+ * Run: node pv-loop-visualizer/tools/tune.js [presetName]
+ * Reports per-chamber EDV/ESV/SV/EF and circulatory pressures over one beat. */
+'use strict';
+const path = require('path');
+const { CVModel } = require(path.join(__dirname, '..', 'js', 'model.js'));
+let presets = {};
+try { presets = require(path.join(__dirname, '..', 'js', 'presets.js')).presets; } catch (e) {}
+
+function sampleBeat(model, samples) {
+  samples = samples || 2000;
+  const T = model.period();
+  const dtSample = T / samples;
+  const rec = { lv: [], rv: [], la: [], ra: [], t: [], pSa: [], pPa: [], pLa: [], pRa: [] };
+  // align to start of a cardiac cycle
+  const startBeat = model.beat;
+  while (model.beat === startBeat) model._step();
+  for (let i = 0; i < samples; i++) {
+    model.advance(dtSample);
+    rec.t.push(i * dtSample);
+    rec.lv.push({ v: model.V.lv, p: model.P.lv });
+    rec.rv.push({ v: model.V.rv, p: model.P.rv });
+    rec.la.push({ v: model.V.la, p: model.P.la });
+    rec.ra.push({ v: model.V.ra, p: model.P.ra });
+    rec.pSa.push(model.P.sa);
+    rec.pPa.push(model.P.pa);
+    rec.pLa.push(model.P.la);
+    rec.pRa.push(model.P.ra);
+  }
+  return rec;
+}
+
+function chamberMetrics(arr) {
+  let edv = -Infinity, esv = Infinity, pMax = -Infinity, pMin = Infinity;
+  for (const s of arr) {
+    if (s.v > edv) edv = s.v;
+    if (s.v < esv) esv = s.v;
+    if (s.p > pMax) pMax = s.p;
+    if (s.p < pMin) pMin = s.p;
+  }
+  const sv = edv - esv;
+  return { edv, esv, sv, ef: (sv / edv) * 100, pMax, pMin };
+}
+
+function stat(arr) {
+  let mn = Infinity, mx = -Infinity, sum = 0;
+  for (const v of arr) { if (v < mn) mn = v; if (v > mx) mx = v; sum += v; }
+  return { min: mn, max: mx, mean: sum / arr.length };
+}
+
+function run(presetName) {
+  const params = presetName && presets[presetName] ? presets[presetName].params : {};
+  const model = new CVModel(params);
+  model.settle(30);
+  const rec = sampleBeat(model);
+  const hr = model.params.heartRate;
+  const lv = chamberMetrics(rec.lv);
+  const rv = chamberMetrics(rec.rv);
+  const la = chamberMetrics(rec.la);
+  const ra = chamberMetrics(rec.ra);
+  const co = (lv.sv * hr) / 1000;
+  const sa = stat(rec.pSa), pa = stat(rec.pPa), pla = stat(rec.pLa), pra = stat(rec.pRa);
+  let totalVol = 0; for (const k in model.V) totalVol += model.V[k];
+
+  const f = (x, d = 0) => x.toFixed(d);
+  console.log(`\n=== ${presetName || 'default'} (HR ${hr}) ===`);
+  console.log(`LV  EDV ${f(lv.edv)} ESV ${f(lv.esv)} SV ${f(lv.sv)} EF ${f(lv.ef)}%  P ${f(lv.pMin)}–${f(lv.pMax)}`);
+  console.log(`RV  EDV ${f(rv.edv)} ESV ${f(rv.esv)} SV ${f(rv.sv)} EF ${f(rv.ef)}%  P ${f(rv.pMin)}–${f(rv.pMax)}`);
+  console.log(`LA  Vmin ${f(la.esv)} Vmax ${f(la.edv)}  P ${f(la.pMin)}–${f(la.pMax)}`);
+  console.log(`RA  Vmin ${f(ra.esv)} Vmax ${f(ra.edv)}  P ${f(ra.pMin)}–${f(ra.pMax)}`);
+  console.log(`Aorta ${f(sa.min)}/${f(sa.max)} (MAP ${f(sa.mean)})   PA ${f(pa.min)}/${f(pa.max)} (mean ${f(pa.mean)})`);
+  console.log(`LA mean ${f(pla.mean)}  RA mean ${f(pra.mean)}  CO ${f(co, 2)} L/min  Vtot ${f(totalVol)} mL`);
+  return { lv, rv, la, ra, co, sa, pa };
+}
+
+const arg = process.argv[2];
+if (arg === 'all') {
+  run();
+  for (const k of Object.keys(presets)) run(k);
+} else {
+  run(arg);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a fully interactive **pressure–volume (PV) loop visualiser** for all four cardiac chambers — **LV, RV, LA, RA** — under `pv-loop-visualizer/`. It runs a real-time, closed-loop cardiovascular simulation in the browser and lets you reshape the loops by dragging physiological parameters or loading clinical scenarios.

The heart model is grounded in the BioGears engine: the ventricular activation waveform and default LV/RV elastances come directly from `Cardiovascular.cpp` (`CalculateHeartElastance`, double-Hill α₁=0.303, α₂=0.508, n₁=1.32, n₂=21.9) and `BioGearsConfiguration.cpp` (LV Ees 2.49, RV Ees 1.08). It extends BioGears by adding **actively contracting atria** so all four chambers produce true PV loops.

No build step and no dependencies — open `index.html` directly or serve the folder with `python3 -m http.server`.

## Demo

**Normal resting adult** (EF ~60%, MAP ~98, CO ~5.2 L/min):

![Normal PV loops](https://cursor.com/artifacts/c/art-cdf26ee9-b551-4dd5-93e6-4f04e62b4c45)

**Systolic heart failure (HFrEF)** — dilated, rightward-shifted LV loop, EF 21%:

![HFrEF](https://cursor.com/artifacts/c/art-eac73c4c-f8ab-49bb-a4b1-9ebddc4f1569)

**Atria-only view** auto-zooms to reveal the low-pressure LA/RA loops:

![Atria loops](https://cursor.com/artifacts/c/art-1b5c2f55-3462-403a-b648-8bb9db47724b)

**Mitral regurgitation** — rounded LV loop with no isovolumic phase, giant LA v-wave:

![Mitral regurgitation](https://cursor.com/artifacts/c/art-2c523e3c-b046-4390-aa75-39f11fa7de8f)

## What's included

- **Closed-loop model** (`js/model.js`): 8 compartments (4 chambers + systemic/pulmonary arteries & veins), time-varying-elastance chambers (active ESPVR + exponential EDPVR), diode valves with stenosis/regurgitation, volume-conserving sub-stepped integrator. Runs in both the browser and Node.
- **11 clinical scenarios** (`js/presets.js`): normal, exercise, HFrEF, HFpEF, hypertension, hemorrhage, aortic stenosis/regurgitation, mitral stenosis/regurgitation, pulmonary hypertension.
- **Three live renderers** (`js/plots.js`): PV loops (with dashed ESPVR/EDPVR reference lines, auto-scaling axes, optional "compare with Normal" ghost), scrolling Wiggers waveforms, and a cardiac schematic with live filling + valve states + flow.
- **Interactive controls + metrics** (`js/ui.js`): sliders for HR, preload, per-chamber contractility & stiffness, SVR/PVR, compliances, and all four valves; live hemodynamics (EDV/ESV/SV/EF, MAP, CO, PA pressures) with abnormal-value flags.
- **Headless tuning harness** (`tools/tune.js`): `node pv-loop-visualizer/tools/tune.js all` validates every scenario against physiologic targets.

## Validation

- All JS files pass `node --check`.
- `tools/tune.js all` produces physiologic steady-state values for every scenario (e.g. Normal: LV 123/50 mL, EF 59%, 114/76 mmHg, MAP 98, CO 5.2 L/min).
- Headless Chrome smoke test: page loads with **no console errors or page errors**; loops, waveforms, schematic, metrics, presets, and chamber toggles all render and update correctly.

## Notes

- Educational tool — clearly marked *not for clinical use*.
- Self-contained; nothing in the existing C++ build is touched.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b84c48a5-9dde-4ee0-8d4f-8bd8447a5af8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b84c48a5-9dde-4ee0-8d4f-8bd8447a5af8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a self-contained, browser-runnable four-chamber PV-loop visualiser (`pv-loop-visualizer/`) with a closed-loop cardiovascular model, 11 clinical presets, three canvas renderers, and a Node.js headless validation harness — no build step required.

- **`model.js`** implements an 8-compartment explicit-Euler integrator with BioGears-derived double-Hill ventricular activation and time-varying elastance; compartment volume floors prevent NaN but can silently inject/destroy blood volume in extreme scenarios, contradicting the \"volume-conserving\" claim in the PR description.
- **`plots.js`** renders PV loops, Wiggers waveforms, and a live cardiac schematic on Canvas; a float/integer comparison in `fit()` causes the canvas width to be re-assigned on every animation frame on devices with non-integer device pixel ratios (1.25×, 1.5×, 1.75×).
- **`ui.js`** metric cards hardcode BSA = 1.9 m² for the cardiac index across all 11 scenarios with no label disclosure.

<h3>Confidence Score: 3/5</h3>

Safe to merge as an educational tool; the volume-floor issue only manifests visually under extreme parameter combinations and never crashes the page.

The volume floor clamps in _step() can break the closed-loop blood-volume invariant under combinations like maximum contractility + hemorrhage + low SVR, causing total circulating volume to drift silently upward over time. The model is advertised as volume-conserving so this gap between the claim and the implementation deserves attention before broader use.

model.js (volume floor logic) and plots.js (DPR comparison in fit()) warrant a second look before the tool is published or used as a teaching reference.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pv-loop-visualizer/js/model.js | Core cardiovascular simulation: time-varying elastance chambers, valve flow, explicit-Euler integrator. Volume floor clamps can silently violate the closed-loop volume conservation invariant under extreme parameters. |
| pv-loop-visualizer/js/app.js | Animation glue: owns the rAF loop, beat-aligned recording, axis smoothing, preset wiring. Logic is sound; the ghost/seed pattern is correct and frame timing is properly capped. |
| pv-loop-visualizer/js/plots.js | Canvas renderers for PV loops, Wiggers waveforms, and cardiac schematic. Non-integer DPR devices trigger a canvas-width assignment on every frame due to float/int comparison mismatch. |
| pv-loop-visualizer/js/ui.js | Data-driven control panel and metrics rendering. Cardiac index hardcodes BSA=1.9 m² across all 11 scenarios without any label disclosure. |
| pv-loop-visualizer/js/presets.js | 11 clinical scenario parameter overrides; values are physiologically reasonable and consistent with the model's parameter space. |
| pv-loop-visualizer/tools/tune.js | Headless Node.js validation harness; correctly imports model and presets, samples one beat after 30-beat settle, and reports per-chamber and circulatory metrics. |
| pv-loop-visualizer/index.html | Minimal HTML shell; script load order (model → presets → plots → ui → app) is correct and all referenced element IDs are present. |
| pv-loop-visualizer/styles.css | Dark-theme stylesheet for the visualiser layout; no functional issues. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph model["model.js - CVModel"]
        A[ventricularActivation / atrialActivation] --> B[chamberPressure: ESPVR + EDPVR blend]
        B --> C[valveFlow: MV AV TV PV]
        C --> D[_step: explicit-Euler V update]
        D -->|volume floors| D
        D --> E[advance / settle]
    end
    subgraph app["app.js - animation loop"]
        F[rAF frame] --> G{running?}
        G -- yes --> H[model.advance x sampleDt]
        G -- no --> I[model._evaluate]
        H --> J[record: beat-aligned loop + wave]
        J --> K[updateAxes / updateWaveScale]
    end
    subgraph render["plots.js - renderers"]
        L[drawPVLoops]
        M[drawWaves: Wiggers]
        N[drawHeart: schematic]
    end
    K --> L
    K --> M
    K --> N
    subgraph ui["ui.js + presets.js"]
        O[SLIDER_GROUPS buildControls] --> P[onChange model.params]
        Q[11 scenarios] --> R[applyPreset]
    end
    P --> model
    R --> model
    L --> S[renderMetrics]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apv-loop-visualizer%2Fjs%2Fmodel.js%3A245-253%0A**Volume%20floor%20clamps%20break%20the%20closed-loop%20conservation%20invariant**%0A%0AWhen%20any%20compartment%20is%20clamped%20to%20its%20floor%20%28e.g.%2C%20%60V.lv%20%3D%200.5%60%29%2C%20the%20%22rescued%22%20volume%20is%20not%20redistributed%20to%20another%20compartment%20%E2%80%94%20it%20is%20simply%20created%20out%20of%20nothing.%20Over%20many%20beats%20under%20extreme%20parameters%20%28e.g.%2C%20severe%20hemorrhage%20%2B%20high%20contractility%20%2B%20low%20SVR%29%2C%20several%20floors%20can%20fire%20simultaneously%2C%20causing%20total%20circulating%20volume%20to%20silently%20drift%20upward%20from%20%60params.bloodVolume%60.%20The%20PR%20description%20calls%20this%20a%20%22volume-conserving%20sub-stepped%20integrator%2C%22%20but%20this%20floor%20implementation%20breaks%20that%20invariant.%20The%20fix%20is%20to%20redistribute%20the%20clamped%20delta%20to%20the%20systemic%20venous%20compartment%20%28%60V.sv%60%29%2C%20which%20acts%20as%20the%20preload%20reservoir%20for%20all%20other%20rescaling%20throughout%20the%20model.%0A%0A%23%23%23%20Issue%202%20of%203%0Apv-loop-visualizer%2Fjs%2Fplots.js%3A25-28%0AOn%20devices%20with%20a%20non-integer%20device%20pixel%20ratio%20%281.25%C3%97%2C%201.5%C3%97%2C%201.75%C3%97%20%E2%80%94%20common%20on%20Android%20phones%20and%20Windows%20laptops%29%2C%20%60w%20*%20dpr%60%20produces%20a%20float%20%28e.g.%20126.25%29%2C%20but%20%60canvas.width%60%20stores%20integers.%20The%20comparison%20%60canvas.width%20!%3D%3D%20126.25%60%20is%20always%20%60true%60%2C%20so%20%60canvas.width%20%3D%20126.25%60%20is%20assigned%20on%20every%20frame.%20Per%20spec%20this%20clears%20the%20canvas%20and%20resets%20the%20context%20state%20on%20each%20tick%2C%20and%20the%20%60setTransform%60%20that%20follows%20uses%20the%20unrounded%20DPR%2C%20leaving%20a%20sub-pixel%20sizing%20discrepancy.%20Rounding%20before%20both%20the%20comparison%20and%20assignment%20fixes%20this.%0A%0A%60%60%60suggestion%0A%20%20%20%20var%20pw%20%3D%20Math.round%28w%20*%20dpr%29%2C%20ph%20%3D%20Math.round%28h%20*%20dpr%29%3B%0A%20%20%20%20if%20%28canvas.width%20!%3D%3D%20pw%20%7C%7C%20canvas.height%20!%3D%3D%20ph%29%20%7B%0A%20%20%20%20%20%20canvas.width%20%3D%20pw%3B%0A%20%20%20%20%20%20canvas.height%20%3D%20ph%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Apv-loop-visualizer%2Fjs%2Fui.js%3A210%0AThe%20cardiac%20index%20is%20computed%20by%20dividing%20CO%20by%20a%20hardcoded%20BSA%20of%201.9%20m%C2%B2%2C%20regardless%20of%20the%20scenario.%20A%20patient%20in%20hemorrhage%2C%20a%20child-sized%20model%2C%20or%20the%20exercise%20scenario%20all%20produce%20the%20same%20denominator.%20The%20label%20gives%20no%20indication%20that%20BSA%20is%20fixed%2C%20which%20can%20mislead%20users%20comparing%20cardiac%20index%20across%20scenarios.%20At%20minimum%20the%20label%20should%20clarify%20the%20assumption%2C%20or%20BSA%20should%20vary%20with%20%60bloodVolume%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20row%28'Cardiac%20index'%2C%20%28m.co%20%2F%201.9%29.toFixed%281%29%20%2B%20'%20L%2Fmin%2Fm%C2%B2%20%28BSA%201.9%20m%C2%B2%29'%29%29%3B%0A%60%60%60%0A%0A&pr=2&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apv-loop-visualizer%2Fjs%2Fmodel.js%3A245-253%0A**Volume%20floor%20clamps%20break%20the%20closed-loop%20conservation%20invariant**%0A%0AWhen%20any%20compartment%20is%20clamped%20to%20its%20floor%20%28e.g.%2C%20%60V.lv%20%3D%200.5%60%29%2C%20the%20%22rescued%22%20volume%20is%20not%20redistributed%20to%20another%20compartment%20%E2%80%94%20it%20is%20simply%20created%20out%20of%20nothing.%20Over%20many%20beats%20under%20extreme%20parameters%20%28e.g.%2C%20severe%20hemorrhage%20%2B%20high%20contractility%20%2B%20low%20SVR%29%2C%20several%20floors%20can%20fire%20simultaneously%2C%20causing%20total%20circulating%20volume%20to%20silently%20drift%20upward%20from%20%60params.bloodVolume%60.%20The%20PR%20description%20calls%20this%20a%20%22volume-conserving%20sub-stepped%20integrator%2C%22%20but%20this%20floor%20implementation%20breaks%20that%20invariant.%20The%20fix%20is%20to%20redistribute%20the%20clamped%20delta%20to%20the%20systemic%20venous%20compartment%20%28%60V.sv%60%29%2C%20which%20acts%20as%20the%20preload%20reservoir%20for%20all%20other%20rescaling%20throughout%20the%20model.%0A%0A%23%23%23%20Issue%202%20of%203%0Apv-loop-visualizer%2Fjs%2Fplots.js%3A25-28%0AOn%20devices%20with%20a%20non-integer%20device%20pixel%20ratio%20%281.25%C3%97%2C%201.5%C3%97%2C%201.75%C3%97%20%E2%80%94%20common%20on%20Android%20phones%20and%20Windows%20laptops%29%2C%20%60w%20*%20dpr%60%20produces%20a%20float%20%28e.g.%20126.25%29%2C%20but%20%60canvas.width%60%20stores%20integers.%20The%20comparison%20%60canvas.width%20!%3D%3D%20126.25%60%20is%20always%20%60true%60%2C%20so%20%60canvas.width%20%3D%20126.25%60%20is%20assigned%20on%20every%20frame.%20Per%20spec%20this%20clears%20the%20canvas%20and%20resets%20the%20context%20state%20on%20each%20tick%2C%20and%20the%20%60setTransform%60%20that%20follows%20uses%20the%20unrounded%20DPR%2C%20leaving%20a%20sub-pixel%20sizing%20discrepancy.%20Rounding%20before%20both%20the%20comparison%20and%20assignment%20fixes%20this.%0A%0A%60%60%60suggestion%0A%20%20%20%20var%20pw%20%3D%20Math.round%28w%20*%20dpr%29%2C%20ph%20%3D%20Math.round%28h%20*%20dpr%29%3B%0A%20%20%20%20if%20%28canvas.width%20!%3D%3D%20pw%20%7C%7C%20canvas.height%20!%3D%3D%20ph%29%20%7B%0A%20%20%20%20%20%20canvas.width%20%3D%20pw%3B%0A%20%20%20%20%20%20canvas.height%20%3D%20ph%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Apv-loop-visualizer%2Fjs%2Fui.js%3A210%0AThe%20cardiac%20index%20is%20computed%20by%20dividing%20CO%20by%20a%20hardcoded%20BSA%20of%201.9%20m%C2%B2%2C%20regardless%20of%20the%20scenario.%20A%20patient%20in%20hemorrhage%2C%20a%20child-sized%20model%2C%20or%20the%20exercise%20scenario%20all%20produce%20the%20same%20denominator.%20The%20label%20gives%20no%20indication%20that%20BSA%20is%20fixed%2C%20which%20can%20mislead%20users%20comparing%20cardiac%20index%20across%20scenarios.%20At%20minimum%20the%20label%20should%20clarify%20the%20assumption%2C%20or%20BSA%20should%20vary%20with%20%60bloodVolume%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20row%28'Cardiac%20index'%2C%20%28m.co%20%2F%201.9%29.toFixed%281%29%20%2B%20'%20L%2Fmin%2Fm%C2%B2%20%28BSA%201.9%20m%C2%B2%29'%29%29%3B%0A%60%60%60%0A%0A&repo=zpankz%2Fbiogears&pr=2&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22zpankz%2Fbiogears%22%20on%20the%20existing%20branch%20%22cursor%2Fpv-loop-visualiser-5af8%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fpv-loop-visualiser-5af8%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apv-loop-visualizer%2Fjs%2Fmodel.js%3A245-253%0A**Volume%20floor%20clamps%20break%20the%20closed-loop%20conservation%20invariant**%0A%0AWhen%20any%20compartment%20is%20clamped%20to%20its%20floor%20%28e.g.%2C%20%60V.lv%20%3D%200.5%60%29%2C%20the%20%22rescued%22%20volume%20is%20not%20redistributed%20to%20another%20compartment%20%E2%80%94%20it%20is%20simply%20created%20out%20of%20nothing.%20Over%20many%20beats%20under%20extreme%20parameters%20%28e.g.%2C%20severe%20hemorrhage%20%2B%20high%20contractility%20%2B%20low%20SVR%29%2C%20several%20floors%20can%20fire%20simultaneously%2C%20causing%20total%20circulating%20volume%20to%20silently%20drift%20upward%20from%20%60params.bloodVolume%60.%20The%20PR%20description%20calls%20this%20a%20%22volume-conserving%20sub-stepped%20integrator%2C%22%20but%20this%20floor%20implementation%20breaks%20that%20invariant.%20The%20fix%20is%20to%20redistribute%20the%20clamped%20delta%20to%20the%20systemic%20venous%20compartment%20%28%60V.sv%60%29%2C%20which%20acts%20as%20the%20preload%20reservoir%20for%20all%20other%20rescaling%20throughout%20the%20model.%0A%0A%23%23%23%20Issue%202%20of%203%0Apv-loop-visualizer%2Fjs%2Fplots.js%3A25-28%0AOn%20devices%20with%20a%20non-integer%20device%20pixel%20ratio%20%281.25%C3%97%2C%201.5%C3%97%2C%201.75%C3%97%20%E2%80%94%20common%20on%20Android%20phones%20and%20Windows%20laptops%29%2C%20%60w%20*%20dpr%60%20produces%20a%20float%20%28e.g.%20126.25%29%2C%20but%20%60canvas.width%60%20stores%20integers.%20The%20comparison%20%60canvas.width%20!%3D%3D%20126.25%60%20is%20always%20%60true%60%2C%20so%20%60canvas.width%20%3D%20126.25%60%20is%20assigned%20on%20every%20frame.%20Per%20spec%20this%20clears%20the%20canvas%20and%20resets%20the%20context%20state%20on%20each%20tick%2C%20and%20the%20%60setTransform%60%20that%20follows%20uses%20the%20unrounded%20DPR%2C%20leaving%20a%20sub-pixel%20sizing%20discrepancy.%20Rounding%20before%20both%20the%20comparison%20and%20assignment%20fixes%20this.%0A%0A%60%60%60suggestion%0A%20%20%20%20var%20pw%20%3D%20Math.round%28w%20*%20dpr%29%2C%20ph%20%3D%20Math.round%28h%20*%20dpr%29%3B%0A%20%20%20%20if%20%28canvas.width%20!%3D%3D%20pw%20%7C%7C%20canvas.height%20!%3D%3D%20ph%29%20%7B%0A%20%20%20%20%20%20canvas.width%20%3D%20pw%3B%0A%20%20%20%20%20%20canvas.height%20%3D%20ph%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Apv-loop-visualizer%2Fjs%2Fui.js%3A210%0AThe%20cardiac%20index%20is%20computed%20by%20dividing%20CO%20by%20a%20hardcoded%20BSA%20of%201.9%20m%C2%B2%2C%20regardless%20of%20the%20scenario.%20A%20patient%20in%20hemorrhage%2C%20a%20child-sized%20model%2C%20or%20the%20exercise%20scenario%20all%20produce%20the%20same%20denominator.%20The%20label%20gives%20no%20indication%20that%20BSA%20is%20fixed%2C%20which%20can%20mislead%20users%20comparing%20cardiac%20index%20across%20scenarios.%20At%20minimum%20the%20label%20should%20clarify%20the%20assumption%2C%20or%20BSA%20should%20vary%20with%20%60bloodVolume%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20row%28'Cardiac%20index'%2C%20%28m.co%20%2F%201.9%29.toFixed%281%29%20%2B%20'%20L%2Fmin%2Fm%C2%B2%20%28BSA%201.9%20m%C2%B2%29'%29%29%3B%0A%60%60%60%0A%0A&repo=zpankz%2Fbiogears&pr=2&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22zpankz%2Fbiogears%22%20on%20the%20existing%20branch%20%22cursor%2Fpv-loop-visualiser-5af8%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fpv-loop-visualiser-5af8%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apv-loop-visualizer%2Fjs%2Fmodel.js%3A245-253%0A**Volume%20floor%20clamps%20break%20the%20closed-loop%20conservation%20invariant**%0A%0AWhen%20any%20compartment%20is%20clamped%20to%20its%20floor%20%28e.g.%2C%20%60V.lv%20%3D%200.5%60%29%2C%20the%20%22rescued%22%20volume%20is%20not%20redistributed%20to%20another%20compartment%20%E2%80%94%20it%20is%20simply%20created%20out%20of%20nothing.%20Over%20many%20beats%20under%20extreme%20parameters%20%28e.g.%2C%20severe%20hemorrhage%20%2B%20high%20contractility%20%2B%20low%20SVR%29%2C%20several%20floors%20can%20fire%20simultaneously%2C%20causing%20total%20circulating%20volume%20to%20silently%20drift%20upward%20from%20%60params.bloodVolume%60.%20The%20PR%20description%20calls%20this%20a%20%22volume-conserving%20sub-stepped%20integrator%2C%22%20but%20this%20floor%20implementation%20breaks%20that%20invariant.%20The%20fix%20is%20to%20redistribute%20the%20clamped%20delta%20to%20the%20systemic%20venous%20compartment%20%28%60V.sv%60%29%2C%20which%20acts%20as%20the%20preload%20reservoir%20for%20all%20other%20rescaling%20throughout%20the%20model.%0A%0A%23%23%23%20Issue%202%20of%203%0Apv-loop-visualizer%2Fjs%2Fplots.js%3A25-28%0AOn%20devices%20with%20a%20non-integer%20device%20pixel%20ratio%20%281.25%C3%97%2C%201.5%C3%97%2C%201.75%C3%97%20%E2%80%94%20common%20on%20Android%20phones%20and%20Windows%20laptops%29%2C%20%60w%20*%20dpr%60%20produces%20a%20float%20%28e.g.%20126.25%29%2C%20but%20%60canvas.width%60%20stores%20integers.%20The%20comparison%20%60canvas.width%20!%3D%3D%20126.25%60%20is%20always%20%60true%60%2C%20so%20%60canvas.width%20%3D%20126.25%60%20is%20assigned%20on%20every%20frame.%20Per%20spec%20this%20clears%20the%20canvas%20and%20resets%20the%20context%20state%20on%20each%20tick%2C%20and%20the%20%60setTransform%60%20that%20follows%20uses%20the%20unrounded%20DPR%2C%20leaving%20a%20sub-pixel%20sizing%20discrepancy.%20Rounding%20before%20both%20the%20comparison%20and%20assignment%20fixes%20this.%0A%0A%60%60%60suggestion%0A%20%20%20%20var%20pw%20%3D%20Math.round%28w%20*%20dpr%29%2C%20ph%20%3D%20Math.round%28h%20*%20dpr%29%3B%0A%20%20%20%20if%20%28canvas.width%20!%3D%3D%20pw%20%7C%7C%20canvas.height%20!%3D%3D%20ph%29%20%7B%0A%20%20%20%20%20%20canvas.width%20%3D%20pw%3B%0A%20%20%20%20%20%20canvas.height%20%3D%20ph%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Apv-loop-visualizer%2Fjs%2Fui.js%3A210%0AThe%20cardiac%20index%20is%20computed%20by%20dividing%20CO%20by%20a%20hardcoded%20BSA%20of%201.9%20m%C2%B2%2C%20regardless%20of%20the%20scenario.%20A%20patient%20in%20hemorrhage%2C%20a%20child-sized%20model%2C%20or%20the%20exercise%20scenario%20all%20produce%20the%20same%20denominator.%20The%20label%20gives%20no%20indication%20that%20BSA%20is%20fixed%2C%20which%20can%20mislead%20users%20comparing%20cardiac%20index%20across%20scenarios.%20At%20minimum%20the%20label%20should%20clarify%20the%20assumption%2C%20or%20BSA%20should%20vary%20with%20%60bloodVolume%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20row%28'Cardiac%20index'%2C%20%28m.co%20%2F%201.9%29.toFixed%281%29%20%2B%20'%20L%2Fmin%2Fm%C2%B2%20%28BSA%201.9%20m%C2%B2%29'%29%29%3B%0A%60%60%60%0A%0A&repo=zpankz%2Fbiogears"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add interactive four-chamber PV-loop vis..."](https://github.com/zpankz/biogears/commit/2f50c8ac31a52f56c9e7165cf019d304947d400c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36610304)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->